### PR TITLE
ENG-562: Forecast feature

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,8 +78,8 @@ RUN \
 # Production image, copy all the files and run next
 FROM base AS runner
 
-# Install pnpm and tsx for pre-deploy commands
-RUN corepack enable pnpm && npm install -g tsx
+# Install pnpm, postgresql-client (for pg_isready in entrypoint), and tsx
+RUN apk add --no-cache postgresql-client && corepack enable pnpm && npm install -g tsx
 
 WORKDIR /app
 
@@ -115,6 +115,10 @@ COPY --from=builder --chown=nextjs:nodejs /app/pnpm-lock.yaml ./pnpm-lock.yaml
 # Ensure .env file can be created if needed by drizzle-kit
 RUN mkdir -p /app && chown -R nextjs:nodejs /app
 
+# Copy entrypoint script
+COPY --chown=nextjs:nodejs docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
+
 USER nextjs
 
 EXPOSE 3000
@@ -124,4 +128,6 @@ ENV PORT=3000
 # server.js is created by next build from the standalone output
 # https://nextjs.org/docs/pages/api-reference/config/next-config-js/output
 ENV HOSTNAME="0.0.0.0"
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["node", "server.js"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+set -e
+
+echo "============================================"
+echo "  Summit Finance Docker Entrypoint"
+echo "============================================"
+
+# Wait for database to be ready
+wait_for_db() {
+  echo "Waiting for database to be ready..."
+
+  DB_HOST=$(echo $DATABASE_URL | sed -n 's|.*@\([^:/]*\).*|\1|p')
+  DB_PORT=$(echo $DATABASE_URL | sed -n 's|.*:\([0-9]*\)/.*|\1|p')
+  DB_PORT=${DB_PORT:-5432}
+
+  MAX_RETRIES=30
+  RETRY_COUNT=0
+
+  while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+    if pg_isready -h "$DB_HOST" -p "$DB_PORT" > /dev/null 2>&1; then
+      echo "Database is ready!"
+      return 0
+    fi
+
+    RETRY_COUNT=$((RETRY_COUNT + 1))
+    echo "Waiting for database... (attempt $RETRY_COUNT/$MAX_RETRIES)"
+    sleep 2
+  done
+
+  echo "ERROR: Database not available after $MAX_RETRIES attempts"
+  exit 1
+}
+
+# Run database migrations
+run_db_setup() {
+  echo ""
+  echo "Running database setup..."
+
+  if [ "$SKIP_DB_SETUP" = "true" ]; then
+    echo "Skipping database setup (SKIP_DB_SETUP=true)"
+    return 0
+  fi
+
+  # Use drizzle-kit push for schema sync (reliable for both fresh and existing DBs)
+  echo "Syncing database schema..."
+  if pnpm run push 2>&1; then
+    echo "Database schema synced successfully!"
+  else
+    echo "WARNING: Schema sync failed, continuing anyway..."
+  fi
+}
+
+echo ""
+echo "Environment:"
+echo "  NODE_ENV: ${NODE_ENV:-production}"
+echo "  SKIP_DB_SETUP: ${SKIP_DB_SETUP:-false}"
+echo ""
+
+wait_for_db
+run_db_setup
+
+echo ""
+echo "============================================"
+echo "  Starting Summit Finance"
+echo "============================================"
+echo ""
+
+exec "$@"

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/(authenticated)/forecasts/[id]/comparison/page.tsx
+++ b/src/app/(authenticated)/forecasts/[id]/comparison/page.tsx
@@ -1,0 +1,11 @@
+import { Metadata } from 'next';
+import ForecastComparisonPage from '@/components/forecasts/ForecastComparisonPage';
+
+export const metadata: Metadata = {
+  title: 'Budget vs Actuals | Summit Finance',
+};
+
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <ForecastComparisonPage forecastId={parseInt(id)} />;
+}

--- a/src/app/(authenticated)/forecasts/[id]/import/page.tsx
+++ b/src/app/(authenticated)/forecasts/[id]/import/page.tsx
@@ -1,0 +1,11 @@
+import { Metadata } from 'next';
+import ForecastImportPage from '@/components/forecasts/ForecastImportPage';
+
+export const metadata: Metadata = {
+  title: 'Import CSV | Summit Finance',
+};
+
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <ForecastImportPage forecastId={parseInt(id)} />;
+}

--- a/src/app/(authenticated)/forecasts/[id]/page.tsx
+++ b/src/app/(authenticated)/forecasts/[id]/page.tsx
@@ -1,0 +1,11 @@
+import { Metadata } from 'next';
+import ForecastEditorPage from '@/components/forecasts/ForecastEditorPage';
+
+export const metadata: Metadata = {
+  title: 'Forecast Editor | Summit Finance',
+};
+
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <ForecastEditorPage forecastId={parseInt(id)} />;
+}

--- a/src/app/(authenticated)/forecasts/[id]/tracking/page.tsx
+++ b/src/app/(authenticated)/forecasts/[id]/tracking/page.tsx
@@ -1,0 +1,11 @@
+import { Metadata } from 'next';
+import ForecastTrackingPage from '@/components/forecasts/ForecastTrackingPage';
+
+export const metadata: Metadata = {
+  title: 'Forecast Tracking | Summit Finance',
+};
+
+export default async function Page({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <ForecastTrackingPage forecastId={parseInt(id)} />;
+}

--- a/src/app/(authenticated)/forecasts/new/page.tsx
+++ b/src/app/(authenticated)/forecasts/new/page.tsx
@@ -1,0 +1,10 @@
+import { Metadata } from 'next';
+import NewForecastPage from '@/components/forecasts/NewForecastPage';
+
+export const metadata: Metadata = {
+  title: 'New Forecast | Summit Finance',
+};
+
+export default function Page() {
+  return <NewForecastPage />;
+}

--- a/src/app/(authenticated)/forecasts/page.tsx
+++ b/src/app/(authenticated)/forecasts/page.tsx
@@ -1,0 +1,11 @@
+import { Metadata } from 'next';
+import ForecastsListPage from '@/components/forecasts/ForecastsListPage';
+
+export const metadata: Metadata = {
+  title: 'Forecasts | Summit Finance',
+  description: 'Manage your financial forecasts and budgets',
+};
+
+export default function ForecastsPage() {
+  return <ForecastsListPage />;
+}

--- a/src/app/api/forecasts/[id]/apply-assumptions/route.ts
+++ b/src/app/api/forecasts/[id]/apply-assumptions/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { forecasts } from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
+import { applyAssumptions } from '@/lib/forecasts/assumptions';
+import { withAuth } from '@/lib/auth/getAuthInfo';
+
+// POST /api/forecasts/[id]/apply-assumptions
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withAuth<any>(request, async (authInfo) => {
+    const { companyId } = authInfo;
+    const { id } = await params;
+    const forecastId = parseInt(id);
+
+    const [forecast] = await db
+      .select()
+      .from(forecasts)
+      .where(and(eq(forecasts.id, forecastId), eq(forecasts.companyId, companyId), eq(forecasts.softDelete, false)));
+
+    if (!forecast) {
+      return NextResponse.json({ message: 'Forecast not found' }, { status: 404 });
+    }
+
+    await applyAssumptions(forecastId, companyId);
+
+    return NextResponse.json({ message: 'Assumptions applied successfully' });
+  });
+}

--- a/src/app/api/forecasts/[id]/assumptions/route.ts
+++ b/src/app/api/forecasts/[id]/assumptions/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import {
+  forecasts,
+  forecastVariables,
+  forecastGrowthRules,
+  forecastSeasonalityWeights,
+} from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
+import { forecastAssumptionsSchema } from '@/lib/validations/forecast';
+import { withAuth } from '@/lib/auth/getAuthInfo';
+
+async function verifyForecast(forecastId: number, companyId: number) {
+  const [f] = await db
+    .select()
+    .from(forecasts)
+    .where(and(eq(forecasts.id, forecastId), eq(forecasts.companyId, companyId), eq(forecasts.softDelete, false)));
+  return f ?? null;
+}
+
+// GET /api/forecasts/[id]/assumptions
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withAuth<any>(request, async (authInfo) => {
+    const { companyId } = authInfo;
+    const { id } = await params;
+    const forecastId = parseInt(id);
+
+    if (!await verifyForecast(forecastId, companyId)) {
+      return NextResponse.json({ message: 'Forecast not found' }, { status: 404 });
+    }
+
+    const [variables, growthRules, seasonalityWeights] = await Promise.all([
+      db.select().from(forecastVariables).where(eq(forecastVariables.forecastId, forecastId)),
+      db.select().from(forecastGrowthRules).where(eq(forecastGrowthRules.forecastId, forecastId)),
+      db.select().from(forecastSeasonalityWeights).where(eq(forecastSeasonalityWeights.forecastId, forecastId)),
+    ]);
+
+    return NextResponse.json({ variables, growthRules, seasonalityWeights });
+  });
+}
+
+// PUT /api/forecasts/[id]/assumptions – Replace all assumptions
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withAuth<any>(request, async (authInfo) => {
+    const { companyId } = authInfo;
+    const { id } = await params;
+    const forecastId = parseInt(id);
+
+    if (!await verifyForecast(forecastId, companyId)) {
+      return NextResponse.json({ message: 'Forecast not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const parsed = forecastAssumptionsSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ message: 'Validation failed', errors: parsed.error.format() }, { status: 400 });
+    }
+
+    const { variables, growthRules, seasonalityWeights } = parsed.data;
+    const now = new Date();
+
+    // Replace variables
+    if (variables !== undefined) {
+      await db.delete(forecastVariables).where(eq(forecastVariables.forecastId, forecastId));
+      if (variables.length > 0) {
+        await db.insert(forecastVariables).values(
+          variables.map((v) => ({ forecastId, ...v, createdAt: now, updatedAt: now }))
+        );
+      }
+    }
+
+    // Replace growth rules
+    if (growthRules !== undefined) {
+      await db.delete(forecastGrowthRules).where(eq(forecastGrowthRules.forecastId, forecastId));
+      if (growthRules.length > 0) {
+        await db.insert(forecastGrowthRules).values(
+          growthRules.map((r) => ({
+            forecastId,
+            scopeType: r.scopeType,
+            scopeId: r.scopeId ?? null,
+            year: r.year,
+            growthRate: r.growthRate,
+            createdAt: now,
+            updatedAt: now,
+          }))
+        );
+      }
+    }
+
+    // Replace seasonality weights
+    if (seasonalityWeights !== undefined) {
+      await db.delete(forecastSeasonalityWeights).where(eq(forecastSeasonalityWeights.forecastId, forecastId));
+      if (seasonalityWeights.length > 0) {
+        await db.insert(forecastSeasonalityWeights).values(
+          seasonalityWeights.map((w) => ({
+            forecastId,
+            scopeType: w.scopeType,
+            scopeId: w.scopeId ?? null,
+            month: w.month,
+            weight: w.weight,
+            createdAt: now,
+            updatedAt: now,
+          }))
+        );
+      }
+    }
+
+    return NextResponse.json({ message: 'Assumptions updated' });
+  });
+}

--- a/src/app/api/forecasts/[id]/comparison/route.ts
+++ b/src/app/api/forecasts/[id]/comparison/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { forecasts } from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
+import { getForecastComparison } from '@/lib/forecasts/comparison';
+import { withAuth } from '@/lib/auth/getAuthInfo';
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withAuth<any>(request, async (authInfo) => {
+    const { companyId } = authInfo;
+    const { id } = await params;
+    const forecastId = parseInt(id);
+
+    const [forecast] = await db
+      .select()
+      .from(forecasts)
+      .where(and(eq(forecasts.id, forecastId), eq(forecasts.companyId, companyId), eq(forecasts.softDelete, false)));
+
+    if (!forecast) {
+      return NextResponse.json({ message: 'Forecast not found' }, { status: 404 });
+    }
+
+    const sp = request.nextUrl.searchParams;
+    const startPeriod = sp.get('startPeriod') ?? undefined;
+    const endPeriod = sp.get('endPeriod') ?? undefined;
+
+    const comparison = await getForecastComparison(forecastId, companyId, startPeriod, endPeriod);
+    return NextResponse.json(comparison);
+  });
+}

--- a/src/app/api/forecasts/[id]/expense-periods/bulk/route.ts
+++ b/src/app/api/forecasts/[id]/expense-periods/bulk/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { forecasts, forecastPeriodValues } from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
+import { forecastBulkPeriodValuesSchema } from '@/lib/validations/forecast';
+import { withAuth } from '@/lib/auth/getAuthInfo';
+
+// PUT /api/forecasts/[id]/expense-periods/bulk – Upsert monthly expense period values
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withAuth<any>(request, async (authInfo) => {
+    const { companyId } = authInfo;
+    const { id } = await params;
+    const forecastId = parseInt(id);
+
+    const [forecast] = await db
+      .select()
+      .from(forecasts)
+      .where(and(eq(forecasts.id, forecastId), eq(forecasts.companyId, companyId), eq(forecasts.softDelete, false)));
+
+    if (!forecast) {
+      return NextResponse.json({ message: 'Forecast not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const parsed = forecastBulkPeriodValuesSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ message: 'Validation failed', errors: parsed.error.format() }, { status: 400 });
+    }
+
+    for (const v of parsed.data.values) {
+      await db
+        .insert(forecastPeriodValues)
+        .values({
+          forecastId,
+          itemId: v.itemId,
+          period: v.period,
+          amount: v.amount,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .onConflictDoUpdate({
+          target: [forecastPeriodValues.itemId, forecastPeriodValues.period],
+          set: { amount: v.amount, updatedAt: new Date() },
+        });
+    }
+
+    return NextResponse.json({ message: 'Values upserted', count: parsed.data.values.length });
+  });
+}

--- a/src/app/api/forecasts/[id]/import/route.ts
+++ b/src/app/api/forecasts/[id]/import/route.ts
@@ -1,0 +1,149 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { forecasts, forecastStreams, forecastItems, forecastPeriodValues } from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
+import { withAuth } from '@/lib/auth/getAuthInfo';
+
+/**
+ * Parse a simple CSV string into rows of objects.
+ * Expected header: stream,item,category,YYYY-MM,YYYY-MM,...
+ */
+function parseCsv(text: string): Array<Record<string, string>> {
+  const lines = text.split(/\r?\n/).filter((l) => l.trim().length > 0);
+  if (lines.length < 2) return [];
+  const headers = lines[0].split(',').map((h) => h.trim());
+  return lines.slice(1).map((line) => {
+    const values = line.split(',').map((v) => v.trim());
+    return Object.fromEntries(headers.map((h, i) => [h, values[i] ?? '']));
+  });
+}
+
+// POST /api/forecasts/[id]/import
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withAuth<any>(request, async (authInfo) => {
+    const { companyId } = authInfo;
+    const { id } = await params;
+    const forecastId = parseInt(id);
+
+    const [forecast] = await db
+      .select()
+      .from(forecasts)
+      .where(and(eq(forecasts.id, forecastId), eq(forecasts.companyId, companyId), eq(forecasts.softDelete, false)));
+
+    if (!forecast) {
+      return NextResponse.json({ message: 'Forecast not found' }, { status: 404 });
+    }
+
+    const contentType = request.headers.get('content-type') ?? '';
+    let csvText: string;
+
+    if (contentType.includes('multipart/form-data')) {
+      const form = await request.formData();
+      const file = form.get('file');
+      if (!file || typeof file === 'string') {
+        return NextResponse.json({ message: 'file field required' }, { status: 400 });
+      }
+      csvText = await (file as File).text();
+    } else {
+      csvText = await request.text();
+    }
+
+    const rows = parseCsv(csvText);
+    if (rows.length === 0) {
+      return NextResponse.json({ message: 'No data rows found in CSV' }, { status: 400 });
+    }
+
+    const headers = Object.keys(rows[0]);
+    const periodHeaders = headers.filter((h) => /^\d{4}-\d{2}$/.test(h));
+
+    if (periodHeaders.length === 0) {
+      return NextResponse.json({ message: 'No YYYY-MM period columns found' }, { status: 400 });
+    }
+
+    // Load existing streams for this forecast
+    const existingStreams = await db
+      .select()
+      .from(forecastStreams)
+      .where(eq(forecastStreams.forecastId, forecastId));
+
+    const streamCache: Map<string, number> = new Map(existingStreams.map((s) => [s.name, s.id]));
+
+    const existingItems = await db
+      .select()
+      .from(forecastItems)
+      .where(eq(forecastItems.forecastId, forecastId));
+
+    const itemCache: Map<string, number> = new Map(existingItems.map((i) => [`${i.streamId}__${i.name}`, i.id]));
+
+    const now = new Date();
+    let upsertCount = 0;
+
+    for (const row of rows) {
+      const streamName = row['stream'];
+      const itemName = row['item'];
+
+      if (!streamName || !itemName) continue;
+
+      // Get or create stream
+      let streamId = streamCache.get(streamName);
+      if (!streamId) {
+        const inferredType = /expense/i.test(streamName) ? 'expense' : 'revenue';
+        const [newStream] = await db
+          .insert(forecastStreams)
+          .values({ forecastId, name: streamName, type: inferredType, order: 0, createdAt: now, updatedAt: now })
+          .returning();
+        streamId = newStream.id;
+        streamCache.set(streamName, streamId);
+      }
+
+      // Get or create item
+      const itemKey = `${streamId}__${itemName}`;
+      let itemId = itemCache.get(itemKey);
+      if (!itemId) {
+        const [newItem] = await db
+          .insert(forecastItems)
+          .values({
+            forecastId,
+            streamId,
+            name: itemName,
+            description: null,
+            order: 0,
+            incomeCategoryId: null,
+            expenseCategoryId: null,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .returning();
+        itemId = newItem.id;
+        itemCache.set(itemKey, itemId);
+      }
+
+      // Upsert period values
+      for (const period of periodHeaders) {
+        const rawAmount = row[period];
+        if (!rawAmount || rawAmount.trim() === '') continue;
+        const amount = parseFloat(rawAmount.replace(/[^0-9.-]/g, ''));
+        if (isNaN(amount)) continue;
+
+        await db
+          .insert(forecastPeriodValues)
+          .values({
+            forecastId,
+            itemId,
+            period,
+            amount: amount.toFixed(2),
+            createdAt: now,
+            updatedAt: now,
+          })
+          .onConflictDoUpdate({
+            target: [forecastPeriodValues.itemId, forecastPeriodValues.period],
+            set: { amount: amount.toFixed(2), updatedAt: now },
+          });
+
+        upsertCount++;
+      }
+    }
+
+    return NextResponse.json({ message: 'Import complete', rowsProcessed: rows.length, valuesUpserted: upsertCount });
+  });
+}

--- a/src/app/api/forecasts/[id]/items/route.ts
+++ b/src/app/api/forecasts/[id]/items/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { forecasts, forecastItems } from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
+import { forecastItemSchema } from '@/lib/validations/forecast';
+import { withAuth } from '@/lib/auth/getAuthInfo';
+
+async function verifyForecast(forecastId: number, companyId: number) {
+  const [f] = await db
+    .select()
+    .from(forecasts)
+    .where(and(eq(forecasts.id, forecastId), eq(forecasts.companyId, companyId), eq(forecasts.softDelete, false)));
+  return f ?? null;
+}
+
+// POST /api/forecasts/[id]/items
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withAuth<any>(request, async (authInfo) => {
+    const { companyId } = authInfo;
+    const { id } = await params;
+    const forecastId = parseInt(id);
+
+    if (!await verifyForecast(forecastId, companyId)) {
+      return NextResponse.json({ message: 'Forecast not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const parsed = forecastItemSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ message: 'Validation failed', errors: parsed.error.format() }, { status: 400 });
+    }
+
+    const [created] = await db
+      .insert(forecastItems)
+      .values({
+        forecastId,
+        ...parsed.data,
+        description: parsed.data.description ?? null,
+        incomeCategoryId: parsed.data.incomeCategoryId ?? null,
+        expenseCategoryId: parsed.data.expenseCategoryId ?? null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .returning();
+
+    return NextResponse.json(created, { status: 201 });
+  });
+}
+
+// PUT /api/forecasts/[id]/items – requires itemId in body
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withAuth<any>(request, async (authInfo) => {
+    const { companyId } = authInfo;
+    const { id } = await params;
+    const forecastId = parseInt(id);
+
+    if (!await verifyForecast(forecastId, companyId)) {
+      return NextResponse.json({ message: 'Forecast not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const { itemId, ...rest } = body;
+    if (!itemId) return NextResponse.json({ message: 'itemId is required' }, { status: 400 });
+
+    const parsed = forecastItemSchema.partial().safeParse(rest);
+    if (!parsed.success) {
+      return NextResponse.json({ message: 'Validation failed', errors: parsed.error.format() }, { status: 400 });
+    }
+
+    const [updated] = await db
+      .update(forecastItems)
+      .set({ ...parsed.data, updatedAt: new Date() })
+      .where(and(eq(forecastItems.id, itemId), eq(forecastItems.forecastId, forecastId)))
+      .returning();
+
+    if (!updated) return NextResponse.json({ message: 'Item not found' }, { status: 404 });
+    return NextResponse.json(updated);
+  });
+}
+
+// DELETE /api/forecasts/[id]/items?itemId=...
+export async function DELETE(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withAuth<any>(request, async (authInfo) => {
+    const { companyId } = authInfo;
+    const { id } = await params;
+    const forecastId = parseInt(id);
+
+    if (!await verifyForecast(forecastId, companyId)) {
+      return NextResponse.json({ message: 'Forecast not found' }, { status: 404 });
+    }
+
+    const itemId = parseInt(request.nextUrl.searchParams.get('itemId') ?? '');
+    if (isNaN(itemId)) return NextResponse.json({ message: 'itemId query param required' }, { status: 400 });
+
+    await db
+      .delete(forecastItems)
+      .where(and(eq(forecastItems.id, itemId), eq(forecastItems.forecastId, forecastId)));
+
+    return NextResponse.json({ message: 'Item deleted' });
+  });
+}

--- a/src/app/api/forecasts/[id]/metrics/route.ts
+++ b/src/app/api/forecasts/[id]/metrics/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { forecasts } from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
+import { getForecastMetrics } from '@/lib/forecasts/metrics';
+import { withAuth } from '@/lib/auth/getAuthInfo';
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withAuth<any>(request, async (authInfo) => {
+    const { companyId } = authInfo;
+    const { id } = await params;
+    const forecastId = parseInt(id);
+
+    const [forecast] = await db
+      .select()
+      .from(forecasts)
+      .where(and(eq(forecasts.id, forecastId), eq(forecasts.companyId, companyId), eq(forecasts.softDelete, false)));
+
+    if (!forecast) {
+      return NextResponse.json({ message: 'Forecast not found' }, { status: 404 });
+    }
+
+    const metrics = await getForecastMetrics(forecastId);
+    return NextResponse.json(metrics);
+  });
+}

--- a/src/app/api/forecasts/[id]/revenue-periods/bulk/route.ts
+++ b/src/app/api/forecasts/[id]/revenue-periods/bulk/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { forecasts, forecastPeriodValues } from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
+import { forecastBulkPeriodValuesSchema } from '@/lib/validations/forecast';
+import { withAuth } from '@/lib/auth/getAuthInfo';
+
+// PUT /api/forecasts/[id]/revenue-periods/bulk – Upsert monthly revenue period values
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withAuth<any>(request, async (authInfo) => {
+    const { companyId } = authInfo;
+    const { id } = await params;
+    const forecastId = parseInt(id);
+
+    const [forecast] = await db
+      .select()
+      .from(forecasts)
+      .where(and(eq(forecasts.id, forecastId), eq(forecasts.companyId, companyId), eq(forecasts.softDelete, false)));
+
+    if (!forecast) {
+      return NextResponse.json({ message: 'Forecast not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const parsed = forecastBulkPeriodValuesSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ message: 'Validation failed', errors: parsed.error.format() }, { status: 400 });
+    }
+
+    for (const v of parsed.data.values) {
+      await db
+        .insert(forecastPeriodValues)
+        .values({
+          forecastId,
+          itemId: v.itemId,
+          period: v.period,
+          amount: v.amount,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .onConflictDoUpdate({
+          target: [forecastPeriodValues.itemId, forecastPeriodValues.period],
+          set: { amount: v.amount, updatedAt: new Date() },
+        });
+    }
+
+    return NextResponse.json({ message: 'Values upserted', count: parsed.data.values.length });
+  });
+}

--- a/src/app/api/forecasts/[id]/route.ts
+++ b/src/app/api/forecasts/[id]/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { forecasts, forecastStreams, forecastItems } from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
+import { forecastSchema } from '@/lib/validations/forecast';
+import { withAuth } from '@/lib/auth/getAuthInfo';
+
+// GET /api/forecasts/[id] – Forecast detail with streams + items
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withAuth<any>(request, async (authInfo) => {
+    const { companyId } = authInfo;
+    const { id } = await params;
+    const forecastId = parseInt(id);
+
+    const [forecast] = await db
+      .select()
+      .from(forecasts)
+      .where(
+        and(eq(forecasts.id, forecastId), eq(forecasts.companyId, companyId), eq(forecasts.softDelete, false))
+      );
+
+    if (!forecast) {
+      return NextResponse.json({ message: 'Forecast not found' }, { status: 404 });
+    }
+
+    const streams = await db
+      .select()
+      .from(forecastStreams)
+      .where(eq(forecastStreams.forecastId, forecastId))
+      .orderBy(forecastStreams.order);
+
+    const items = await db
+      .select()
+      .from(forecastItems)
+      .where(eq(forecastItems.forecastId, forecastId))
+      .orderBy(forecastItems.order);
+
+    return NextResponse.json({ ...forecast, streams, items });
+  });
+}
+
+// PUT /api/forecasts/[id] – Update a forecast
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withAuth<any>(request, async (authInfo) => {
+    const { companyId } = authInfo;
+    const { id } = await params;
+    const forecastId = parseInt(id);
+
+    const [existing] = await db
+      .select()
+      .from(forecasts)
+      .where(and(eq(forecasts.id, forecastId), eq(forecasts.companyId, companyId), eq(forecasts.softDelete, false)));
+
+    if (!existing) {
+      return NextResponse.json({ message: 'Forecast not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const parsed = forecastSchema.partial().safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { message: 'Validation failed', errors: parsed.error.format() },
+        { status: 400 }
+      );
+    }
+
+    const [updated] = await db
+      .update(forecasts)
+      .set({ ...parsed.data, updatedAt: new Date() })
+      .where(eq(forecasts.id, forecastId))
+      .returning();
+
+    return NextResponse.json(updated);
+  });
+}
+
+// DELETE /api/forecasts/[id] – Soft delete
+export async function DELETE(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withAuth<any>(request, async (authInfo) => {
+    const { companyId } = authInfo;
+    const { id } = await params;
+    const forecastId = parseInt(id);
+
+    const [existing] = await db
+      .select()
+      .from(forecasts)
+      .where(and(eq(forecasts.id, forecastId), eq(forecasts.companyId, companyId), eq(forecasts.softDelete, false)));
+
+    if (!existing) {
+      return NextResponse.json({ message: 'Forecast not found' }, { status: 404 });
+    }
+
+    await db
+      .update(forecasts)
+      .set({ softDelete: true, updatedAt: new Date() })
+      .where(eq(forecasts.id, forecastId));
+
+    return NextResponse.json({ message: 'Forecast deleted' });
+  });
+}

--- a/src/app/api/forecasts/[id]/streams/route.ts
+++ b/src/app/api/forecasts/[id]/streams/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { forecasts, forecastStreams } from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
+import { forecastStreamSchema } from '@/lib/validations/forecast';
+import { withAuth } from '@/lib/auth/getAuthInfo';
+
+async function verifyForecast(forecastId: number, companyId: number) {
+  const [forecast] = await db
+    .select()
+    .from(forecasts)
+    .where(and(eq(forecasts.id, forecastId), eq(forecasts.companyId, companyId), eq(forecasts.softDelete, false)));
+  return forecast ?? null;
+}
+
+// POST /api/forecasts/[id]/streams – Create a stream
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withAuth<any>(request, async (authInfo) => {
+    const { companyId } = authInfo;
+    const { id } = await params;
+    const forecastId = parseInt(id);
+
+    if (!await verifyForecast(forecastId, companyId)) {
+      return NextResponse.json({ message: 'Forecast not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const parsed = forecastStreamSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ message: 'Validation failed', errors: parsed.error.format() }, { status: 400 });
+    }
+
+    const [created] = await db
+      .insert(forecastStreams)
+      .values({ forecastId, ...parsed.data, createdAt: new Date(), updatedAt: new Date() })
+      .returning();
+
+    return NextResponse.json(created, { status: 201 });
+  });
+}
+
+// PUT /api/forecasts/[id]/streams – Update a stream (requires streamId in body)
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withAuth<any>(request, async (authInfo) => {
+    const { companyId } = authInfo;
+    const { id } = await params;
+    const forecastId = parseInt(id);
+
+    if (!await verifyForecast(forecastId, companyId)) {
+      return NextResponse.json({ message: 'Forecast not found' }, { status: 404 });
+    }
+
+    const body = await request.json();
+    const { streamId, ...rest } = body;
+    if (!streamId) {
+      return NextResponse.json({ message: 'streamId is required' }, { status: 400 });
+    }
+
+    const parsed = forecastStreamSchema.partial().safeParse(rest);
+    if (!parsed.success) {
+      return NextResponse.json({ message: 'Validation failed', errors: parsed.error.format() }, { status: 400 });
+    }
+
+    const [updated] = await db
+      .update(forecastStreams)
+      .set({ ...parsed.data, updatedAt: new Date() })
+      .where(and(eq(forecastStreams.id, streamId), eq(forecastStreams.forecastId, forecastId)))
+      .returning();
+
+    if (!updated) return NextResponse.json({ message: 'Stream not found' }, { status: 404 });
+    return NextResponse.json(updated);
+  });
+}
+
+// DELETE /api/forecasts/[id]/streams – Delete a stream (requires streamId query param)
+export async function DELETE(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withAuth<any>(request, async (authInfo) => {
+    const { companyId } = authInfo;
+    const { id } = await params;
+    const forecastId = parseInt(id);
+
+    if (!await verifyForecast(forecastId, companyId)) {
+      return NextResponse.json({ message: 'Forecast not found' }, { status: 404 });
+    }
+
+    const streamId = parseInt(request.nextUrl.searchParams.get('streamId') ?? '');
+    if (isNaN(streamId)) {
+      return NextResponse.json({ message: 'streamId query param required' }, { status: 400 });
+    }
+
+    await db
+      .delete(forecastStreams)
+      .where(and(eq(forecastStreams.id, streamId), eq(forecastStreams.forecastId, forecastId)));
+
+    return NextResponse.json({ message: 'Stream deleted' });
+  });
+}

--- a/src/app/api/forecasts/[id]/summary/route.ts
+++ b/src/app/api/forecasts/[id]/summary/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { forecasts } from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
+import { getForecastSummary } from '@/lib/forecasts/summary';
+import { withAuth } from '@/lib/auth/getAuthInfo';
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withAuth<any>(request, async (authInfo) => {
+    const { companyId } = authInfo;
+    const { id } = await params;
+    const forecastId = parseInt(id);
+
+    const [forecast] = await db
+      .select()
+      .from(forecasts)
+      .where(and(eq(forecasts.id, forecastId), eq(forecasts.companyId, companyId), eq(forecasts.softDelete, false)));
+
+    if (!forecast) {
+      return NextResponse.json({ message: 'Forecast not found' }, { status: 404 });
+    }
+
+    const summary = await getForecastSummary(forecastId);
+    return NextResponse.json(summary);
+  });
+}

--- a/src/app/api/forecasts/[id]/tracking/route.ts
+++ b/src/app/api/forecasts/[id]/tracking/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { forecasts } from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
+import { getForecastTracking } from '@/lib/forecasts/tracking';
+import { withAuth } from '@/lib/auth/getAuthInfo';
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  return withAuth<any>(request, async (authInfo) => {
+    const { companyId } = authInfo;
+    const { id } = await params;
+    const forecastId = parseInt(id);
+
+    const [forecast] = await db
+      .select()
+      .from(forecasts)
+      .where(and(eq(forecasts.id, forecastId), eq(forecasts.companyId, companyId), eq(forecasts.softDelete, false)));
+
+    if (!forecast) {
+      return NextResponse.json({ message: 'Forecast not found' }, { status: 404 });
+    }
+
+    const sp = request.nextUrl.searchParams;
+    const startPeriod = sp.get('startPeriod') ?? undefined;
+    const endPeriod = sp.get('endPeriod') ?? undefined;
+
+    const tracking = await getForecastTracking(forecastId, companyId, startPeriod, endPeriod);
+    return NextResponse.json(tracking);
+  });
+}

--- a/src/app/api/forecasts/route.ts
+++ b/src/app/api/forecasts/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { forecasts } from '@/lib/db/schema';
+import { and, eq, desc } from 'drizzle-orm';
+import { forecastSchema } from '@/lib/validations/forecast';
+import { withAuth } from '@/lib/auth/getAuthInfo';
+
+// GET /api/forecasts – List all forecasts for the company
+export async function GET(request: NextRequest) {
+  return withAuth<any>(request, async (authInfo) => {
+    const { companyId } = authInfo;
+
+    const results = await db
+      .select()
+      .from(forecasts)
+      .where(and(eq(forecasts.companyId, companyId), eq(forecasts.softDelete, false)))
+      .orderBy(desc(forecasts.createdAt));
+
+    return NextResponse.json(results);
+  });
+}
+
+// POST /api/forecasts – Create a new forecast
+export async function POST(request: NextRequest) {
+  return withAuth<any>(request, async (authInfo) => {
+    const { companyId } = authInfo;
+    const body = await request.json();
+
+    const parsed = forecastSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { message: 'Validation failed', errors: parsed.error.format() },
+        { status: 400 }
+      );
+    }
+
+    const { name, description, startDate, endDate, currency } = parsed.data;
+
+    const [created] = await db
+      .insert(forecasts)
+      .values({
+        companyId,
+        name,
+        description: description ?? null,
+        startDate,
+        endDate,
+        currency,
+        softDelete: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .returning();
+
+    return NextResponse.json(created, { status: 201 });
+  });
+}

--- a/src/components/forecasts/AssumptionsPanel.tsx
+++ b/src/components/forecasts/AssumptionsPanel.tsx
@@ -1,0 +1,285 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Plus, Trash2, Settings2 } from 'lucide-react';
+
+interface Variable {
+  key: string;
+  value: string;
+  description?: string;
+}
+
+interface GrowthRule {
+  scopeType: 'global' | 'stream' | 'item';
+  scopeId?: number | null;
+  year: number;
+  growthRate: string;
+}
+
+interface SeasonalityWeight {
+  scopeType: 'global' | 'item';
+  scopeId?: number | null;
+  month: number;
+  weight: string;
+}
+
+interface ScopeOption {
+  id: number;
+  name: string;
+}
+
+interface AssumptionsPanelProps {
+  forecastId: number;
+  streams: ScopeOption[];
+  items: ScopeOption[];
+  variables: Variable[];
+  growthRules: GrowthRule[];
+  seasonalityWeights: SeasonalityWeight[];
+  onSave: (data: { variables: Variable[]; growthRules: GrowthRule[]; seasonalityWeights: SeasonalityWeight[] }) => Promise<void>;
+  onApply: () => Promise<void>;
+}
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+export function AssumptionsPanel({
+  forecastId,
+  streams,
+  items,
+  variables: initialVars,
+  growthRules: initialRules,
+  seasonalityWeights: initialWeights,
+  onSave,
+  onApply,
+}: AssumptionsPanelProps) {
+  const [variables, setVariables] = useState<Variable[]>(initialVars);
+  const [growthRules, setGrowthRules] = useState<GrowthRule[]>(initialRules);
+  const [weights, setWeights] = useState<SeasonalityWeight[]>(initialWeights);
+  const [saving, setSaving] = useState(false);
+  const [applying, setApplying] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      await onSave({ variables, growthRules, seasonalityWeights: weights });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleApply() {
+    setApplying(true);
+    try {
+      await onApply();
+    } finally {
+      setApplying(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Settings2 className="h-4 w-4 mr-2" /> Assumptions
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Forecast Assumptions</DialogTitle>
+        </DialogHeader>
+
+        <Tabs defaultValue="growth" className="mt-2">
+          <TabsList className="w-full">
+            <TabsTrigger value="growth" className="flex-1">Growth Rates</TabsTrigger>
+            <TabsTrigger value="seasonality" className="flex-1">Seasonality</TabsTrigger>
+            <TabsTrigger value="variables" className="flex-1">Variables</TabsTrigger>
+          </TabsList>
+
+          {/* Growth Rules */}
+          <TabsContent value="growth" className="space-y-3 mt-3">
+            <p className="text-xs text-muted-foreground">
+              Define year-over-year growth rates. Global rules apply to all items unless overridden.
+            </p>
+            {growthRules.map((rule, i) => (
+              <div key={i} className="flex gap-2 items-end flex-wrap">
+                <div className="w-24">
+                  <Label className="text-xs">Scope</Label>
+                  <select
+                    className="w-full border rounded px-2 py-1.5 text-sm"
+                    value={rule.scopeType}
+                    onChange={(e) => {
+                      const next = [...growthRules];
+                      next[i] = { ...next[i], scopeType: e.target.value as GrowthRule['scopeType'], scopeId: null };
+                      setGrowthRules(next);
+                    }}
+                  >
+                    <option value="global">Global</option>
+                    <option value="stream">Stream</option>
+                    <option value="item">Item</option>
+                  </select>
+                </div>
+                {rule.scopeType !== 'global' && (
+                  <div className="flex-1 min-w-[140px]">
+                    <Label className="text-xs">{rule.scopeType === 'stream' ? 'Stream' : 'Item'}</Label>
+                    <select
+                      className="w-full border rounded px-2 py-1.5 text-sm"
+                      value={rule.scopeId ?? ''}
+                      onChange={(e) => {
+                        const next = [...growthRules];
+                        next[i] = { ...next[i], scopeId: e.target.value ? parseInt(e.target.value) : null };
+                        setGrowthRules(next);
+                      }}
+                    >
+                      <option value="">— select —</option>
+                      {(rule.scopeType === 'stream' ? streams : items).map((opt) => (
+                        <option key={opt.id} value={opt.id}>{opt.name}</option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+                <div className="w-20">
+                  <Label className="text-xs">Year</Label>
+                  <Input
+                    type="number"
+                    value={rule.year}
+                    onChange={(e) => {
+                      const next = [...growthRules];
+                      next[i] = { ...next[i], year: parseInt(e.target.value) };
+                      setGrowthRules(next);
+                    }}
+                  />
+                </div>
+                <div className="w-28">
+                  <Label className="text-xs">Growth Rate</Label>
+                  <Input
+                    placeholder="0.20"
+                    value={rule.growthRate}
+                    onChange={(e) => {
+                      const next = [...growthRules];
+                      next[i] = { ...next[i], growthRate: e.target.value };
+                      setGrowthRules(next);
+                    }}
+                  />
+                </div>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="text-destructive"
+                  onClick={() => setGrowthRules(growthRules.filter((_, j) => j !== i))}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            ))}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setGrowthRules([...growthRules, { scopeType: 'global', year: new Date().getFullYear() + 1, growthRate: '0.10' }])}
+            >
+              <Plus className="h-4 w-4 mr-1" /> Add Rule
+            </Button>
+          </TabsContent>
+
+          {/* Seasonality */}
+          <TabsContent value="seasonality" className="space-y-3 mt-3">
+            <p className="text-xs text-muted-foreground">
+              Monthly weights (global) — must sum to 1.0. Leave empty for equal distribution.
+            </p>
+            <div className="grid grid-cols-3 gap-2">
+              {MONTHS.map((month, idx) => {
+                const existing = weights.find((w) => w.scopeType === 'global' && w.month === idx + 1);
+                return (
+                  <div key={idx}>
+                    <Label className="text-xs">{month}</Label>
+                    <Input
+                      type="number"
+                      step="0.0001"
+                      placeholder="0.0833"
+                      value={existing?.weight ?? ''}
+                      onChange={(e) => {
+                        const val = e.target.value;
+                        setWeights((prev) => {
+                          const filtered = prev.filter((w) => !(w.scopeType === 'global' && w.month === idx + 1));
+                          if (val) filtered.push({ scopeType: 'global', month: idx + 1, weight: val });
+                          return filtered;
+                        });
+                      }}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </TabsContent>
+
+          {/* Variables */}
+          <TabsContent value="variables" className="space-y-3 mt-3">
+            <p className="text-xs text-muted-foreground">
+              Named constants for use in descriptions and planning notes.
+            </p>
+            {variables.map((v, i) => (
+              <div key={i} className="flex gap-2 items-end">
+                <div className="flex-1">
+                  <Label className="text-xs">Key</Label>
+                  <Input
+                    value={v.key}
+                    onChange={(e) => {
+                      const next = [...variables];
+                      next[i] = { ...next[i], key: e.target.value };
+                      setVariables(next);
+                    }}
+                  />
+                </div>
+                <div className="flex-1">
+                  <Label className="text-xs">Value</Label>
+                  <Input
+                    value={v.value}
+                    onChange={(e) => {
+                      const next = [...variables];
+                      next[i] = { ...next[i], value: e.target.value };
+                      setVariables(next);
+                    }}
+                  />
+                </div>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="text-destructive"
+                  onClick={() => setVariables(variables.filter((_, j) => j !== i))}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            ))}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setVariables([...variables, { key: '', value: '' }])}
+            >
+              <Plus className="h-4 w-4 mr-1" /> Add Variable
+            </Button>
+          </TabsContent>
+        </Tabs>
+
+        <div className="flex gap-2 mt-4">
+          <Button onClick={handleSave} disabled={saving} className="flex-1">
+            {saving ? 'Saving…' : 'Save Assumptions'}
+          </Button>
+          <Button onClick={handleApply} disabled={applying} variant="outline" className="flex-1">
+            {applying ? 'Applying…' : 'Apply Assumptions'}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/forecasts/ForecastComparisonPage.tsx
+++ b/src/components/forecasts/ForecastComparisonPage.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { ArrowLeft } from 'lucide-react';
+import { VarianceCell } from './VarianceCell';
+import { cn } from '@/lib/utils';
+
+interface ComparisonRow {
+  itemId: number;
+  itemName: string;
+  streamType: 'revenue' | 'expense';
+  period: string;
+  budgeted: number;
+  actual: number;
+  variance: number;
+  variancePct: number | null;
+}
+
+interface ForecastComparisonPageProps {
+  forecastId: number;
+}
+
+function formatCurrency(amount: number) {
+  return new Intl.NumberFormat('en-US', { style: 'decimal', maximumFractionDigits: 0 }).format(amount);
+}
+
+export default function ForecastComparisonPage({ forecastId }: ForecastComparisonPageProps) {
+  const [rows, setRows] = useState<ComparisonRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [forecastName, setForecastName] = useState('');
+
+  useEffect(() => {
+    Promise.all([
+      fetch(`/api/forecasts/${forecastId}`).then((r) => r.json()),
+      fetch(`/api/forecasts/${forecastId}/comparison`).then((r) => r.json()),
+    ]).then(([forecast, comparison]) => {
+      setForecastName(forecast.name ?? '');
+      setRows(comparison);
+    }).finally(() => setLoading(false));
+  }, [forecastId]);
+
+  // Get unique periods and items
+  const periods = [...new Set(rows.map((r) => r.period))].sort();
+  const itemIds = [...new Set(rows.map((r) => r.itemId))];
+
+  // Build matrix: itemId → period → row
+  const matrix: Record<number, Record<string, ComparisonRow>> = {};
+  const itemNames: Record<number, string> = {};
+  for (const row of rows) {
+    if (!matrix[row.itemId]) matrix[row.itemId] = {};
+    matrix[row.itemId][row.period] = row;
+    itemNames[row.itemId] = row.itemName;
+  }
+
+  if (loading) {
+    return (
+      <div className="p-8 flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 space-y-4">
+      <div className="flex items-center gap-3">
+        <Button asChild variant="ghost" size="sm">
+          <Link href={`/forecasts/${forecastId}`}><ArrowLeft className="h-4 w-4 mr-1" /> Back to Editor</Link>
+        </Button>
+        <h1 className="text-2xl font-bold">Budget vs Actuals</h1>
+        {forecastName && <span className="text-muted-foreground text-sm">— {forecastName}</span>}
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="text-center py-12 text-muted-foreground">
+          No comparison data. Make sure items are linked to income/expense categories and have budget values set.
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-md border">
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="bg-muted/50">
+                <th className="sticky left-0 bg-muted/50 text-left px-3 py-2 font-medium min-w-[180px]">Item</th>
+                {periods.map((p) => (
+                  <th key={p} colSpan={3} className="px-2 py-2 text-center font-medium border-l min-w-[200px]">
+                    {p}
+                  </th>
+                ))}
+              </tr>
+              <tr className="bg-muted/30 text-xs text-muted-foreground">
+                <th className="sticky left-0 bg-muted/30 px-3 py-1"></th>
+                {periods.map((p) => (
+                  <React.Fragment key={p}>
+                    <th className="px-2 py-1 text-right border-l">Budget</th>
+                    <th className="px-2 py-1 text-right">Actual</th>
+                    <th className="px-2 py-1 text-right">Variance</th>
+                  </React.Fragment>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {itemIds.map((itemId) => {
+                const firstRow = rows.find((r) => r.itemId === itemId);
+                return (
+                  <tr key={itemId} className="border-t hover:bg-accent/20">
+                    <td className="sticky left-0 bg-background px-3 py-2 font-medium">
+                      {itemNames[itemId]}
+                    </td>
+                    {periods.map((p) => {
+                      const row = matrix[itemId]?.[p];
+                      if (!row) {
+                        return (
+                          <React.Fragment key={p}>
+                            <td className="px-2 py-2 text-right text-muted-foreground/40 border-l">—</td>
+                            <td className="px-2 py-2 text-right text-muted-foreground/40">—</td>
+                            <td className="px-2 py-2 text-right text-muted-foreground/40">—</td>
+                          </React.Fragment>
+                        );
+                      }
+                      const isPositiveVariance = row.streamType === 'revenue'
+                        ? row.variance >= 0
+                        : row.variance <= 0;
+                      return (
+                        <React.Fragment key={p}>
+                          <td className="px-2 py-2 text-right border-l">{formatCurrency(row.budgeted)}</td>
+                          <td className="px-2 py-2 text-right">{formatCurrency(row.actual)}</td>
+                          <td
+                            className={cn(
+                              'px-2 py-2 text-right text-xs',
+                              isPositiveVariance ? 'text-green-600' : 'text-red-600'
+                            )}
+                          >
+                            {row.variance >= 0 ? '+' : ''}{formatCurrency(row.variance)}
+                            {row.variancePct !== null && (
+                              <span className="block text-xs opacity-75">
+                                {row.variancePct >= 0 ? '+' : ''}{row.variancePct.toFixed(1)}%
+                              </span>
+                            )}
+                          </td>
+                        </React.Fragment>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/forecasts/ForecastEditorPage.tsx
+++ b/src/components/forecasts/ForecastEditorPage.tsx
@@ -1,0 +1,445 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { ArrowLeft, Plus, Upload } from 'lucide-react';
+import { ForecastGrid, GridItem, PeriodValue } from './ForecastGrid';
+import { StreamTree, ForecastStream, ForecastItem } from './StreamTree';
+import { AssumptionsPanel } from './AssumptionsPanel';
+
+interface Forecast {
+  id: number;
+  name: string;
+  startDate: string;
+  endDate: string;
+  currency: string;
+  streams: ForecastStream[];
+  items: ForecastItem[];
+}
+
+interface FullForecastItem extends ForecastItem {
+  incomeCategoryId: number | null;
+  expenseCategoryId: number | null;
+}
+
+interface Category {
+  id: number;
+  name: string;
+}
+
+interface ForecastEditorPageProps {
+  forecastId: number;
+}
+
+function generatePeriods(startDate: string, endDate: string): string[] {
+  const periods: string[] = [];
+  const [sy, sm] = startDate.split('-').map(Number);
+  const [ey, em] = endDate.split('-').map(Number);
+  let y = sy, m = sm;
+  while (y < ey || (y === ey && m <= em)) {
+    periods.push(`${y}-${String(m).padStart(2, '0')}`);
+    m++;
+    if (m > 12) { m = 1; y++; }
+  }
+  return periods;
+}
+
+export default function ForecastEditorPage({ forecastId }: ForecastEditorPageProps) {
+  const [forecast, setForecast] = useState<Forecast | null>(null);
+  const [streams, setStreams] = useState<ForecastStream[]>([]);
+  const [items, setItems] = useState<ForecastItem[]>([]);
+  const [periodValues, setPeriodValues] = useState<PeriodValue[]>([]);
+  const [assumptions, setAssumptions] = useState<any>({ variables: [], growthRules: [], seasonalityWeights: [] });
+  const [loading, setLoading] = useState(true);
+  const [selectedYear, setSelectedYear] = useState<number | null>(null);
+
+  // Item edit dialog
+  const [editItem, setEditItem] = useState<FullForecastItem | null>(null);
+  const [incomeCategories, setIncomeCategories] = useState<Category[]>([]);
+  const [expenseCategories, setExpenseCategories] = useState<Category[]>([]);
+  const [editItemSaving, setEditItemSaving] = useState(false);
+
+  // Add stream dialog
+  const [addStreamOpen, setAddStreamOpen] = useState(false);
+  const [newStreamName, setNewStreamName] = useState('');
+  const [newStreamType, setNewStreamType] = useState<'revenue' | 'expense'>('revenue');
+
+  // Add item dialog
+  const [addItemOpen, setAddItemOpen] = useState(false);
+  const [newItemName, setNewItemName] = useState('');
+  const [addItemStreamId, setAddItemStreamId] = useState<number | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      const [forecastRes, assumptionsRes, incCatRes, expCatRes] = await Promise.all([
+        fetch(`/api/forecasts/${forecastId}`),
+        fetch(`/api/forecasts/${forecastId}/assumptions`),
+        fetch(`/api/income-categories`),
+        fetch(`/api/expense-categories`),
+      ]);
+      const forecastData = await forecastRes.json();
+      const assumptionsData = await assumptionsRes.json();
+      const incCatData = await incCatRes.json();
+      const expCatData = await expCatRes.json();
+
+      setForecast(forecastData);
+      setStreams(forecastData.streams ?? []);
+      setItems(forecastData.items ?? []);
+      setAssumptions(assumptionsData);
+      setIncomeCategories(incCatData?.data ?? incCatData ?? []);
+      setExpenseCategories(expCatData?.data ?? expCatData ?? []);
+
+      // Determine initial year
+      const startYear = parseInt(forecastData.startDate.substring(0, 4));
+      setSelectedYear(startYear);
+
+      // Load period values (no per-stream endpoint needed, load all via comparison or separate call)
+      // We'll fetch via the bulk endpoint by reading period values from items
+      // For now, fetch them by loading from the comparison endpoint (which includes budgeted values)
+      // Actually, there's no direct GET for period values. We'll fetch them through the forecast items.
+      // Let's call a simple periods fetch.
+      await loadPeriodValues(forecastData.items ?? [], forecastData.startDate, forecastData.endDate);
+
+      setLoading(false);
+    }
+    load();
+  }, [forecastId]);
+
+  async function loadPeriodValues(forecastItems: ForecastItem[], startDate: string, endDate: string) {
+    if (forecastItems.length === 0) return;
+    // Fetch comparison data (has budgeted values per item per period)
+    const res = await fetch(`/api/forecasts/${forecastId}/comparison`);
+    if (!res.ok) return;
+    const rows: any[] = await res.json();
+    const pvs: PeriodValue[] = rows.map((r) => ({
+      itemId: r.itemId,
+      period: r.period,
+      amount: r.budgeted,
+    }));
+    setPeriodValues(pvs);
+  }
+
+  const periods = forecast ? generatePeriods(forecast.startDate, forecast.endDate) : [];
+  const years = [...new Set(periods.map((p) => parseInt(p.substring(0, 4))))];
+  const visiblePeriods = selectedYear
+    ? periods.filter((p) => p.startsWith(String(selectedYear)))
+    : periods;
+
+  const gridItems: GridItem[] = items.map((item) => {
+    const stream = streams.find((s) => s.id === item.streamId);
+    return {
+      id: item.id,
+      name: item.name,
+      streamId: item.streamId,
+      streamName: stream?.name ?? 'Unknown',
+      streamType: stream?.type ?? 'revenue',
+    };
+  });
+
+  async function handleAddStream() {
+    const res = await fetch(`/api/forecasts/${forecastId}/streams`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: newStreamName, type: newStreamType, order: streams.length }),
+    });
+    if (res.ok) {
+      const stream = await res.json();
+      setStreams((prev) => [...prev, stream]);
+      setNewStreamName('');
+      setAddStreamOpen(false);
+    }
+  }
+
+  async function handleAddItem(streamId: number) {
+    setAddItemStreamId(streamId);
+    setAddItemOpen(true);
+  }
+
+  async function handleCreateItem() {
+    if (!addItemStreamId) return;
+    const res = await fetch(`/api/forecasts/${forecastId}/items`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ streamId: addItemStreamId, name: newItemName, order: items.length }),
+    });
+    if (res.ok) {
+      const item = await res.json();
+      setItems((prev) => [...prev, item]);
+      setNewItemName('');
+      setAddItemOpen(false);
+    }
+  }
+
+  async function handleDeleteStream(streamId: number) {
+    await fetch(`/api/forecasts/${forecastId}/streams?streamId=${streamId}`, { method: 'DELETE' });
+    setStreams((prev) => prev.filter((s) => s.id !== streamId));
+    setItems((prev) => prev.filter((i) => i.streamId !== streamId));
+  }
+
+  async function handleDeleteItem(itemId: number) {
+    await fetch(`/api/forecasts/${forecastId}/items?itemId=${itemId}`, { method: 'DELETE' });
+    setItems((prev) => prev.filter((i) => i.id !== itemId));
+    setPeriodValues((prev) => prev.filter((v) => v.itemId !== itemId));
+  }
+
+  function handleCellChange(itemId: number, period: string, amount: number) {
+    setPeriodValues((prev) => {
+      const filtered = prev.filter((v) => !(v.itemId === itemId && v.period === period));
+      return [...filtered, { itemId, period, amount }];
+    });
+  }
+
+  async function handleBulkSave(changes: PeriodValue[]) {
+    const body = { values: changes.map((c) => ({ itemId: c.itemId, period: c.period, amount: c.amount.toFixed(2) })) };
+    await fetch(`/api/forecasts/${forecastId}/revenue-periods/bulk`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  }
+
+  async function handleSaveAssumptions(data: any) {
+    await fetch(`/api/forecasts/${forecastId}/assumptions`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+    setAssumptions(data);
+  }
+
+  function handleSelectItem(itemId: number) {
+    const item = items.find((i) => i.id === itemId) as FullForecastItem | undefined;
+    if (item) setEditItem({ ...item });
+  }
+
+  async function handleSaveItemCategory() {
+    if (!editItem) return;
+    setEditItemSaving(true);
+    try {
+      const res = await fetch(`/api/forecasts/${forecastId}/items`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          itemId: editItem.id,
+          incomeCategoryId: editItem.incomeCategoryId ?? null,
+          expenseCategoryId: editItem.expenseCategoryId ?? null,
+        }),
+      });
+      if (res.ok) {
+        const updated = await res.json();
+        setItems((prev) => prev.map((i) => (i.id === updated.id ? updated : i)));
+        setEditItem(null);
+      }
+    } finally {
+      setEditItemSaving(false);
+    }
+  }
+
+  async function handleApplyAssumptions() {
+    await fetch(`/api/forecasts/${forecastId}/apply-assumptions`, { method: 'POST' });
+    // Reload period values
+    if (forecast) await loadPeriodValues(items, forecast.startDate, forecast.endDate);
+  }
+
+  if (loading) {
+    return (
+      <div className="p-8 flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+      </div>
+    );
+  }
+
+  if (!forecast) {
+    return <div className="p-8 text-center text-muted-foreground">Forecast not found</div>;
+  }
+
+  return (
+    <div className="flex flex-col h-screen overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between px-6 py-3 border-b bg-background shrink-0">
+        <div className="flex items-center gap-3">
+          <Button asChild variant="ghost" size="sm">
+            <Link href="/forecasts"><ArrowLeft className="h-4 w-4 mr-1" /> Forecasts</Link>
+          </Button>
+          <div>
+            <h1 className="font-bold text-lg leading-tight">{forecast.name}</h1>
+            <p className="text-xs text-muted-foreground">{forecast.startDate} → {forecast.endDate} · {forecast.currency}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {years.map((y) => (
+            <Button
+              key={y}
+              size="sm"
+              variant={selectedYear === y ? 'default' : 'outline'}
+              onClick={() => setSelectedYear(y)}
+            >
+              {y}
+            </Button>
+          ))}
+          <Button size="sm" variant="outline" onClick={() => setSelectedYear(null)}>All</Button>
+          <AssumptionsPanel
+            forecastId={forecastId}
+            streams={streams.map((s) => ({ id: s.id, name: s.name }))}
+            items={items.map((item) => ({ id: item.id, name: item.name }))}
+            variables={assumptions.variables ?? []}
+            growthRules={assumptions.growthRules ?? []}
+            seasonalityWeights={assumptions.seasonalityWeights ?? []}
+            onSave={handleSaveAssumptions}
+            onApply={handleApplyAssumptions}
+          />
+          <Button asChild size="sm" variant="outline">
+            <Link href={`/forecasts/${forecastId}/comparison`}>Compare</Link>
+          </Button>
+          <Button asChild size="sm" variant="outline">
+            <Link href={`/forecasts/${forecastId}/tracking`}>Tracking</Link>
+          </Button>
+          <Button asChild size="sm" variant="outline">
+            <Link href={`/forecasts/${forecastId}/import`}>
+              <Upload className="h-4 w-4 mr-1" /> Import CSV
+            </Link>
+          </Button>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Sidebar */}
+        <div className="w-64 border-r overflow-y-auto p-4 shrink-0">
+          <StreamTree
+            streams={streams}
+            items={items}
+            selectedItemId={editItem?.id}
+            onSelectItem={handleSelectItem}
+            onAddStream={() => setAddStreamOpen(true)}
+            onAddItem={handleAddItem}
+            onDeleteStream={handleDeleteStream}
+            onDeleteItem={handleDeleteItem}
+          />
+        </div>
+
+        {/* Grid */}
+        <div className="flex-1 overflow-auto p-4">
+          {gridItems.length === 0 ? (
+            <div className="flex flex-col items-center justify-center h-full text-center text-muted-foreground">
+              <p className="mb-3">No streams or items yet.</p>
+              <Button onClick={() => setAddStreamOpen(true)}>
+                <Plus className="h-4 w-4 mr-2" /> Add Stream
+              </Button>
+            </div>
+          ) : (
+            <ForecastGrid
+              items={gridItems}
+              periods={visiblePeriods}
+              values={periodValues}
+              onCellChange={handleCellChange}
+              onBulkSave={handleBulkSave}
+              currency={forecast.currency}
+            />
+          )}
+        </div>
+      </div>
+
+      {/* Add Stream Dialog */}
+      <Dialog open={addStreamOpen} onOpenChange={setAddStreamOpen}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>Add Stream</DialogTitle></DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <Label>Name</Label>
+              <Input value={newStreamName} onChange={(e) => setNewStreamName(e.target.value)} placeholder="e.g. Product Revenue" />
+            </div>
+            <div>
+              <Label>Type</Label>
+              <select
+                className="w-full border rounded px-3 py-2 text-sm mt-1"
+                value={newStreamType}
+                onChange={(e) => setNewStreamType(e.target.value as 'revenue' | 'expense')}
+              >
+                <option value="revenue">Revenue</option>
+                <option value="expense">Expense</option>
+              </select>
+            </div>
+            <Button onClick={handleAddStream} disabled={!newStreamName.trim()} className="w-full">Add Stream</Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit Item Dialog — category mapping */}
+      <Dialog open={!!editItem} onOpenChange={(open) => { if (!open) setEditItem(null); }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit Item: {editItem?.name}</DialogTitle>
+          </DialogHeader>
+          {editItem && (
+            <div className="space-y-4">
+              <div>
+                <Label>Income Category</Label>
+                <p className="text-xs text-muted-foreground mb-1">
+                  Link to an income category so actuals flow into comparison/tracking.
+                </p>
+                <select
+                  className="w-full border rounded px-3 py-2 text-sm"
+                  value={editItem.incomeCategoryId ?? ''}
+                  onChange={(e) =>
+                    setEditItem({ ...editItem, incomeCategoryId: e.target.value ? parseInt(e.target.value) : null })
+                  }
+                >
+                  <option value="">— none —</option>
+                  {incomeCategories.map((c) => (
+                    <option key={c.id} value={c.id}>{c.name}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <Label>Expense Category</Label>
+                <p className="text-xs text-muted-foreground mb-1">
+                  Link to an expense category for expense items.
+                </p>
+                <select
+                  className="w-full border rounded px-3 py-2 text-sm"
+                  value={editItem.expenseCategoryId ?? ''}
+                  onChange={(e) =>
+                    setEditItem({ ...editItem, expenseCategoryId: e.target.value ? parseInt(e.target.value) : null })
+                  }
+                >
+                  <option value="">— none —</option>
+                  {expenseCategories.map((c) => (
+                    <option key={c.id} value={c.id}>{c.name}</option>
+                  ))}
+                </select>
+              </div>
+              <Button onClick={handleSaveItemCategory} disabled={editItemSaving} className="w-full">
+                {editItemSaving ? 'Saving…' : 'Save'}
+              </Button>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Add Item Dialog */}
+      <Dialog open={addItemOpen} onOpenChange={setAddItemOpen}>
+        <DialogContent>
+          <DialogHeader><DialogTitle>Add Line Item</DialogTitle></DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <Label>Name</Label>
+              <Input value={newItemName} onChange={(e) => setNewItemName(e.target.value)} placeholder="e.g. SaaS Subscriptions" />
+            </div>
+            <Button onClick={handleCreateItem} disabled={!newItemName.trim()} className="w-full">Add Item</Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/forecasts/ForecastGrid.tsx
+++ b/src/components/forecasts/ForecastGrid.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface GridItem {
+  id: number;
+  name: string;
+  streamId: number;
+  streamName: string;
+  streamType: 'revenue' | 'expense';
+}
+
+export interface PeriodValue {
+  itemId: number;
+  period: string;
+  amount: number;
+}
+
+interface ForecastGridProps {
+  items: GridItem[];
+  periods: string[];   // sorted YYYY-MM strings
+  values: PeriodValue[];
+  onCellChange: (itemId: number, period: string, amount: number) => void;
+  onBulkSave: (changes: PeriodValue[]) => Promise<void>;
+  currency?: string;
+}
+
+function formatAmount(amount: number, currency: string) {
+  if (amount === 0) return '';
+  return new Intl.NumberFormat('en-US', {
+    style: 'decimal',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+export function ForecastGrid({
+  items,
+  periods,
+  values,
+  onCellChange,
+  onBulkSave,
+  currency = 'IDR',
+}: ForecastGridProps) {
+  const [editingCell, setEditingCell] = useState<{ itemId: number; period: string } | null>(null);
+  const [editValue, setEditValue] = useState('');
+  const [pendingChanges, setPendingChanges] = useState<PeriodValue[]>([]);
+  const [saving, setSaving] = useState(false);
+
+  function getValue(itemId: number, period: string): number {
+    // Check pending changes first
+    const pending = pendingChanges.find((c) => c.itemId === itemId && c.period === period);
+    if (pending !== undefined) return pending.amount;
+    return values.find((v) => v.itemId === itemId && v.period === period)?.amount ?? 0;
+  }
+
+  function startEdit(itemId: number, period: string) {
+    setEditingCell({ itemId, period });
+    setEditValue(String(getValue(itemId, period) || ''));
+  }
+
+  function commitEdit(itemId: number, period: string) {
+    const amount = parseFloat(editValue.replace(/[^0-9.-]/g, '')) || 0;
+    setEditingCell(null);
+    onCellChange(itemId, period, amount);
+    setPendingChanges((prev) => {
+      const filtered = prev.filter((c) => !(c.itemId === itemId && c.period === period));
+      return [...filtered, { itemId, period, amount }];
+    });
+  }
+
+  async function handleSave() {
+    if (pendingChanges.length === 0) return;
+    setSaving(true);
+    try {
+      await onBulkSave(pendingChanges);
+      setPendingChanges([]);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // Group items by stream
+  const streamGroups = items.reduce<Map<string, GridItem[]>>((map, item) => {
+    const key = `${item.streamId}__${item.streamName}`;
+    if (!map.has(key)) map.set(key, []);
+    map.get(key)!.push(item);
+    return map;
+  }, new Map());
+
+  // Column totals per period per stream
+  function getStreamTotal(streamId: number, period: string): number {
+    return items.filter((i) => i.streamId === streamId).reduce((sum, i) => sum + getValue(i.id, period), 0);
+  }
+
+  return (
+    <div className="space-y-2">
+      {pendingChanges.length > 0 && (
+        <div className="flex items-center justify-between bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 rounded px-3 py-2 text-sm">
+          <span>{pendingChanges.length} unsaved change{pendingChanges.length !== 1 ? 's' : ''}</span>
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="text-xs font-medium text-yellow-700 dark:text-yellow-300 hover:underline"
+          >
+            {saving ? 'Saving…' : 'Save all'}
+          </button>
+        </div>
+      )}
+
+      <div className="overflow-x-auto rounded-md border">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="bg-muted/50">
+              <th className="sticky left-0 bg-muted/50 text-left px-3 py-2 font-medium min-w-[200px]">
+                Line Item
+              </th>
+              {periods.map((p) => (
+                <th key={p} className="px-2 py-2 text-right font-medium min-w-[90px] whitespace-nowrap">
+                  {p}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {Array.from(streamGroups.entries()).map(([streamKey, streamItems]) => {
+              const firstItem = streamItems[0];
+              return (
+                <React.Fragment key={streamKey}>
+                  {/* Stream header row */}
+                  <tr key={`stream-${streamKey}`} className="bg-muted/30 border-t">
+                    <td
+                      colSpan={1}
+                      className="sticky left-0 bg-muted/30 px-3 py-1.5 font-semibold text-xs uppercase tracking-wide"
+                    >
+                      <span className={cn(
+                        'inline-flex items-center gap-1.5',
+                        firstItem.streamType === 'revenue' ? 'text-green-700' : 'text-red-700'
+                      )}>
+                        {firstItem.streamName}
+                      </span>
+                    </td>
+                    {periods.map((p) => (
+                      <td key={p} className="px-2 py-1.5 text-right text-xs font-medium text-muted-foreground">
+                        {formatAmount(getStreamTotal(firstItem.streamId, p), currency)}
+                      </td>
+                    ))}
+                  </tr>
+
+                  {/* Item rows */}
+                  {streamItems.map((item) => (
+                    <tr key={item.id} className="border-t hover:bg-accent/30 transition-colors">
+                      <td className="sticky left-0 bg-background px-6 py-1.5 text-sm">
+                        {item.name}
+                      </td>
+                      {periods.map((p) => {
+                        const isEditing = editingCell?.itemId === item.id && editingCell?.period === p;
+                        const val = getValue(item.id, p);
+                        const isPending = pendingChanges.some((c) => c.itemId === item.id && c.period === p);
+
+                        return (
+                          <td
+                            key={p}
+                            className={cn(
+                              'px-2 py-1 text-right cursor-pointer',
+                              isPending && 'bg-yellow-50 dark:bg-yellow-900/20'
+                            )}
+                            onClick={() => !isEditing && startEdit(item.id, p)}
+                          >
+                            {isEditing ? (
+                              <input
+                                autoFocus
+                                className="w-full text-right bg-transparent outline-none border-b border-primary"
+                                value={editValue}
+                                onChange={(e) => setEditValue(e.target.value)}
+                                onBlur={() => commitEdit(item.id, p)}
+                                onKeyDown={(e) => {
+                                  if (e.key === 'Enter' || e.key === 'Tab') commitEdit(item.id, p);
+                                  if (e.key === 'Escape') setEditingCell(null);
+                                }}
+                              />
+                            ) : (
+                              <span className={cn(val === 0 ? 'text-muted-foreground/40' : '')}>
+                                {formatAmount(val, currency)}
+                              </span>
+                            )}
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  ))}
+                </React.Fragment>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/forecasts/ForecastImportPage.tsx
+++ b/src/components/forecasts/ForecastImportPage.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useState, useRef } from 'react';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ArrowLeft, Upload, CheckCircle2 } from 'lucide-react';
+
+interface ForecastImportPageProps {
+  forecastId: number;
+}
+
+export default function ForecastImportPage({ forecastId }: ForecastImportPageProps) {
+  const [file, setFile] = useState<File | null>(null);
+  const [preview, setPreview] = useState<string[][] | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [result, setResult] = useState<{ rowsProcessed: number; valuesUpserted: number } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const selected = e.target.files?.[0];
+    if (!selected) return;
+    setFile(selected);
+    setResult(null);
+    setError(null);
+
+    // Preview first 5 rows
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const text = ev.target?.result as string;
+      const lines = text.split(/\r?\n/).filter((l) => l.trim());
+      const rows = lines.slice(0, 6).map((l) => l.split(','));
+      setPreview(rows);
+    };
+    reader.readAsText(selected);
+  }
+
+  async function handleUpload() {
+    if (!file) return;
+    setUploading(true);
+    setError(null);
+
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+
+      const res = await fetch(`/api/forecasts/${forecastId}/import`, {
+        method: 'POST',
+        body: formData,
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.message ?? 'Import failed');
+      } else {
+        setResult(data);
+        setFile(null);
+        setPreview(null);
+      }
+    } catch {
+      setError('An unexpected error occurred');
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto p-8 space-y-6">
+      <div className="flex items-center gap-3">
+        <Button asChild variant="ghost" size="sm">
+          <Link href={`/forecasts/${forecastId}`}><ArrowLeft className="h-4 w-4 mr-1" /> Back to Editor</Link>
+        </Button>
+        <h1 className="text-2xl font-bold">Import CSV</h1>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>CSV Format</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground mb-2">
+            Upload a CSV with the following columns:
+          </p>
+          <pre className="text-xs bg-muted rounded p-3 overflow-x-auto">
+{`stream,item,category,2026-01,2026-02,2026-03,...
+Revenue,SaaS Subscriptions,Software Sales,50000,52000,54000,...
+Expenses,Payroll,HR,80000,80000,80000,...`}
+          </pre>
+          <ul className="text-xs text-muted-foreground mt-3 space-y-1 list-disc list-inside">
+            <li><code>stream</code> — Stream name (created if not exists)</li>
+            <li><code>item</code> — Line item name (created if not exists)</li>
+            <li><code>category</code> — Optional category mapping</li>
+            <li><code>YYYY-MM</code> columns — Monthly amounts</li>
+          </ul>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader><CardTitle>Upload File</CardTitle></CardHeader>
+        <CardContent className="space-y-4">
+          <div
+            className="border-2 border-dashed rounded-lg p-8 text-center cursor-pointer hover:bg-accent/20 transition-colors"
+            onClick={() => inputRef.current?.click()}
+          >
+            <Upload className="h-10 w-10 mx-auto text-muted-foreground mb-2" />
+            <p className="text-sm font-medium">{file ? file.name : 'Click to select a CSV file'}</p>
+            <p className="text-xs text-muted-foreground mt-1">or drag and drop</p>
+            <input
+              ref={inputRef}
+              type="file"
+              accept=".csv,text/csv"
+              className="hidden"
+              onChange={handleFileChange}
+            />
+          </div>
+
+          {preview && (
+            <div>
+              <p className="text-xs font-medium text-muted-foreground mb-2">Preview (first 5 rows):</p>
+              <div className="overflow-x-auto border rounded">
+                <table className="min-w-full text-xs">
+                  <tbody>
+                    {preview.map((row, i) => (
+                      <tr key={i} className={i === 0 ? 'bg-muted/50 font-medium' : 'border-t'}>
+                        {row.map((cell, j) => (
+                          <td key={j} className="px-2 py-1 whitespace-nowrap">{cell}</td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {error && (
+            <div className="text-sm text-destructive bg-destructive/10 rounded p-3">{error}</div>
+          )}
+
+          {result && (
+            <div className="flex items-center gap-3 text-sm text-green-700 bg-green-50 rounded p-3">
+              <CheckCircle2 className="h-5 w-5" />
+              <span>Import complete: {result.rowsProcessed} rows, {result.valuesUpserted} values upserted</span>
+            </div>
+          )}
+
+          <Button onClick={handleUpload} disabled={!file || uploading} className="w-full">
+            {uploading ? 'Importing…' : 'Import CSV'}
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/forecasts/ForecastTrackingPage.tsx
+++ b/src/components/forecasts/ForecastTrackingPage.tsx
@@ -1,0 +1,276 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ArrowLeft, CheckCircle2, AlertTriangle, XCircle, ChevronLeft, ChevronRight } from 'lucide-react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import { cn } from '@/lib/utils';
+
+interface TrackingRow {
+  itemId: number;
+  itemName: string;
+  streamType: 'revenue' | 'expense';
+  period: string;
+  budgeted: number;
+  actual: number;
+  variance: number;
+  variancePct: number | null;
+  status: 'on_track' | 'at_risk' | 'off_track';
+  ratio: number | null;
+}
+
+interface ForecastTrackingPageProps {
+  forecastId: number;
+}
+
+const statusConfig = {
+  on_track: { label: 'On Track', icon: CheckCircle2, color: 'text-green-600', bg: 'bg-green-100 dark:bg-green-900/30' },
+  at_risk:  { label: 'At Risk',  icon: AlertTriangle, color: 'text-yellow-600', bg: 'bg-yellow-100 dark:bg-yellow-900/30' },
+  off_track: { label: 'Off Track', icon: XCircle, color: 'text-red-600', bg: 'bg-red-100 dark:bg-red-900/30' },
+};
+
+function formatCurrency(v: number) {
+  return new Intl.NumberFormat('en-US', { style: 'decimal', maximumFractionDigits: 0 }).format(v);
+}
+
+function formatPeriodLabel(period: string) {
+  const [y, m] = period.split('-');
+  const date = new Date(parseInt(y), parseInt(m) - 1);
+  return date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+}
+
+export default function ForecastTrackingPage({ forecastId }: ForecastTrackingPageProps) {
+  const [allRows, setAllRows] = useState<TrackingRow[]>([]);
+  const [forecastName, setForecastName] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [selectedPeriod, setSelectedPeriod] = useState<string>('');
+
+  useEffect(() => {
+    Promise.all([
+      fetch(`/api/forecasts/${forecastId}`).then((r) => r.json()),
+      fetch(`/api/forecasts/${forecastId}/tracking`).then((r) => r.json()),
+    ]).then(([forecast, tracking]) => {
+      setForecastName(forecast.name ?? '');
+      setAllRows(tracking);
+
+      // Default to current month if within forecast range, else first period
+      const periods: string[] = [...new Set((tracking as TrackingRow[]).map((r) => r.period))].sort() as string[];
+      if (periods.length > 0) {
+        const today = new Date();
+        const currentPeriod = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}`;
+        setSelectedPeriod(periods.includes(currentPeriod) ? currentPeriod : periods[0]);
+      }
+    }).finally(() => setLoading(false));
+  }, [forecastId]);
+
+  if (loading) {
+    return (
+      <div className="p-8 flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+      </div>
+    );
+  }
+
+  const allPeriods = [...new Set(allRows.map((r) => r.period))].sort();
+  const currentIndex = allPeriods.indexOf(selectedPeriod);
+  const rows = allRows.filter((r) => r.period === selectedPeriod);
+
+  // Status counts for the selected period
+  const statusCounts = { on_track: 0, at_risk: 0, off_track: 0 };
+  for (const r of rows) statusCounts[r.status]++;
+  const total = rows.length;
+
+  // Chart data: all periods (for trend view)
+  const chartData = allPeriods.map((p) => {
+    const pRows = allRows.filter((r) => r.period === p);
+    return {
+      period: p,
+      budgeted: pRows.reduce((s, r) => s + r.budgeted, 0),
+      actual: pRows.reduce((s, r) => s + r.actual, 0),
+    };
+  });
+
+  return (
+    <div className="p-6 space-y-6">
+      {/* Page header */}
+      <div className="flex items-center gap-3">
+        <Button asChild variant="ghost" size="sm">
+          <Link href={`/forecasts/${forecastId}`}><ArrowLeft className="h-4 w-4 mr-1" /> Back to Editor</Link>
+        </Button>
+        <h1 className="text-2xl font-bold">Tracking Dashboard</h1>
+        {forecastName && <span className="text-muted-foreground text-sm">— {forecastName}</span>}
+      </div>
+
+      {/* Period navigator */}
+      <div className="flex items-center justify-between rounded-lg border px-4 py-3 bg-muted/30">
+        <Button
+          variant="ghost"
+          size="sm"
+          disabled={currentIndex <= 0}
+          onClick={() => setSelectedPeriod(allPeriods[currentIndex - 1])}
+        >
+          <ChevronLeft className="h-4 w-4 mr-1" /> Prev
+        </Button>
+
+        <div className="flex items-center gap-2">
+          <span className="font-semibold text-lg">
+            {selectedPeriod ? formatPeriodLabel(selectedPeriod) : '—'}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            ({currentIndex + 1} / {allPeriods.length})
+          </span>
+        </div>
+
+        <Button
+          variant="ghost"
+          size="sm"
+          disabled={currentIndex >= allPeriods.length - 1}
+          onClick={() => setSelectedPeriod(allPeriods[currentIndex + 1])}
+        >
+          Next <ChevronRight className="h-4 w-4 ml-1" />
+        </Button>
+      </div>
+
+      {/* Jump to any period */}
+      {allPeriods.length > 1 && (
+        <div className="flex gap-1.5 flex-wrap">
+          {allPeriods.map((p) => (
+            <button
+              key={p}
+              onClick={() => setSelectedPeriod(p)}
+              className={cn(
+                'px-2 py-1 text-xs rounded border transition-colors',
+                p === selectedPeriod
+                  ? 'bg-primary text-primary-foreground border-primary'
+                  : 'hover:bg-accent border-transparent'
+              )}
+            >
+              {p}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Summary cards for selected period */}
+      <div className="grid grid-cols-3 gap-4">
+        {(Object.entries(statusConfig) as Array<[keyof typeof statusConfig, typeof statusConfig[keyof typeof statusConfig]]>).map(([key, cfg]) => {
+          const count = statusCounts[key];
+          const pct = total > 0 ? Math.round((count / total) * 100) : 0;
+          const Icon = cfg.icon;
+          return (
+            <Card key={key}>
+              <CardContent className="pt-6">
+                <div className="flex items-center gap-3">
+                  <div className={cn('p-2 rounded-full', cfg.bg)}>
+                    <Icon className={cn('h-5 w-5', cfg.color)} />
+                  </div>
+                  <div>
+                    <div className="text-2xl font-bold">{count}</div>
+                    <div className="text-sm text-muted-foreground">{cfg.label} ({pct}%)</div>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+
+      {/* Budget vs Actual trend chart */}
+      {chartData.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Budget vs Actual — Full Year Trend</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ResponsiveContainer width="100%" height={220}>
+              <BarChart data={chartData}>
+                <XAxis dataKey="period" tick={{ fontSize: 11 }} />
+                <YAxis tick={{ fontSize: 11 }} />
+                <Tooltip formatter={(v: number) => formatCurrency(v)} />
+                <Legend />
+                <Bar dataKey="budgeted" name="Budgeted" fill="hsl(var(--primary))" opacity={0.5} />
+                <Bar dataKey="actual" name="Actual" fill="hsl(var(--primary))" />
+              </BarChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Per-item table for selected period */}
+      {rows.length > 0 ? (
+        <div className="overflow-x-auto rounded-md border">
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="bg-muted/50">
+                <th className="text-left px-3 py-2 font-medium">Item</th>
+                <th className="text-left px-3 py-2 font-medium">Type</th>
+                <th className="text-right px-3 py-2 font-medium">Budget</th>
+                <th className="text-right px-3 py-2 font-medium">Actual</th>
+                <th className="text-right px-3 py-2 font-medium">Variance</th>
+                <th className="text-center px-3 py-2 font-medium">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => {
+                const cfg = statusConfig[row.status];
+                const Icon = cfg.icon;
+                const isGoodVariance = row.streamType === 'revenue' ? row.variance >= 0 : row.variance <= 0;
+                return (
+                  <tr key={row.itemId} className="border-t hover:bg-accent/20">
+                    <td className="px-3 py-2 font-medium">{row.itemName}</td>
+                    <td className="px-3 py-2">
+                      <span className={cn(
+                        'text-xs px-1.5 py-0.5 rounded-full',
+                        row.streamType === 'revenue' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'
+                      )}>
+                        {row.streamType}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 text-right">{formatCurrency(row.budgeted)}</td>
+                    <td className="px-3 py-2 text-right">{formatCurrency(row.actual)}</td>
+                    <td className={cn('px-3 py-2 text-right', isGoodVariance ? 'text-green-600' : 'text-red-600')}>
+                      {row.variance >= 0 ? '+' : ''}{formatCurrency(row.variance)}
+                      {row.variancePct !== null && (
+                        <span className="text-xs block opacity-75">{row.variancePct.toFixed(1)}%</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2">
+                      <div className={cn('flex items-center justify-center gap-1.5 text-xs font-medium', cfg.color)}>
+                        <Icon className="h-4 w-4" />
+                        {cfg.label}
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+            {/* Period totals */}
+            <tfoot>
+              <tr className="border-t bg-muted/30 font-semibold">
+                <td className="px-3 py-2" colSpan={2}>Total</td>
+                <td className="px-3 py-2 text-right">{formatCurrency(rows.reduce((s, r) => s + r.budgeted, 0))}</td>
+                <td className="px-3 py-2 text-right">{formatCurrency(rows.reduce((s, r) => s + r.actual, 0))}</td>
+                <td className="px-3 py-2 text-right">{formatCurrency(rows.reduce((s, r) => s + r.variance, 0))}</td>
+                <td />
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      ) : (
+        <div className="text-center py-12 text-muted-foreground">
+          No tracking data for this period. Link items to income/expense categories and ensure actuals exist.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/forecasts/ForecastsListPage.tsx
+++ b/src/components/forecasts/ForecastsListPage.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Plus, Calendar, TrendingUp } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+
+interface Forecast {
+  id: number;
+  name: string;
+  description: string | null;
+  startDate: string;
+  endDate: string;
+  currency: string;
+  updatedAt: string;
+}
+
+export default function ForecastsListPage() {
+  const [forecasts, setForecasts] = useState<Forecast[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/forecasts')
+      .then((r) => r.json())
+      .then(setForecasts)
+      .catch(console.error)
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div className="space-y-6 p-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Forecasts</h1>
+          <p className="text-muted-foreground mt-1">Plan and track your financial forecasts</p>
+        </div>
+        <Button asChild>
+          <Link href="/forecasts/new">
+            <Plus className="h-4 w-4 mr-2" /> New Forecast
+          </Link>
+        </Button>
+      </div>
+
+      {loading ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {[1, 2, 3].map((i) => (
+            <Card key={i} className="h-40 animate-pulse bg-muted/40" />
+          ))}
+        </div>
+      ) : forecasts.length === 0 ? (
+        <Card className="p-12 text-center">
+          <TrendingUp className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+          <h3 className="text-lg font-semibold">No forecasts yet</h3>
+          <p className="text-muted-foreground mt-1 mb-4">
+            Create your first financial forecast to start tracking budgets and projections.
+          </p>
+          <Button asChild>
+            <Link href="/forecasts/new">
+              <Plus className="h-4 w-4 mr-2" /> Create Forecast
+            </Link>
+          </Button>
+        </Card>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {forecasts.map((forecast) => (
+            <Card key={forecast.id} className="hover:shadow-md transition-shadow">
+              <CardHeader className="pb-2">
+                <div className="flex items-start justify-between">
+                  <CardTitle className="text-base leading-tight">{forecast.name}</CardTitle>
+                  <Badge variant="outline">{forecast.currency}</Badge>
+                </div>
+                {forecast.description && (
+                  <p className="text-sm text-muted-foreground line-clamp-2">{forecast.description}</p>
+                )}
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-center gap-2 text-sm text-muted-foreground mb-4">
+                  <Calendar className="h-4 w-4" />
+                  <span>{forecast.startDate} → {forecast.endDate}</span>
+                </div>
+                <div className="text-xs text-muted-foreground mb-3">
+                  Updated {new Date(forecast.updatedAt).toLocaleDateString()}
+                </div>
+                <div className="flex gap-2">
+                  <Button asChild size="sm" className="flex-1">
+                    <Link href={`/forecasts/${forecast.id}`}>Edit</Link>
+                  </Button>
+                  <Button asChild size="sm" variant="outline" className="flex-1">
+                    <Link href={`/forecasts/${forecast.id}/comparison`}>Compare</Link>
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/forecasts/NewForecastPage.tsx
+++ b/src/components/forecasts/NewForecastPage.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ArrowLeft } from 'lucide-react';
+import Link from 'next/link';
+
+export default function NewForecastPage() {
+  const router = useRouter();
+  const [form, setForm] = useState({
+    name: '',
+    description: '',
+    startDate: '',
+    endDate: '',
+    currency: 'IDR',
+  });
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      const res = await fetch('/api/forecasts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: form.name,
+          description: form.description || null,
+          startDate: form.startDate,
+          endDate: form.endDate,
+          currency: form.currency,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.message ?? 'Failed to create forecast');
+        return;
+      }
+
+      const created = await res.json();
+      router.push(`/forecasts/${created.id}`);
+    } catch {
+      setError('An unexpected error occurred');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-8 space-y-6">
+      <div className="flex items-center gap-3">
+        <Button asChild variant="ghost" size="sm">
+          <Link href="/forecasts">
+            <ArrowLeft className="h-4 w-4 mr-1" /> Back
+          </Link>
+        </Button>
+        <h1 className="text-2xl font-bold">New Forecast</h1>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Forecast Details</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <Label htmlFor="name">Name *</Label>
+              <Input
+                id="name"
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                placeholder="e.g. FY2026 P&L Forecast"
+                required
+              />
+            </div>
+
+            <div>
+              <Label htmlFor="description">Description</Label>
+              <Textarea
+                id="description"
+                value={form.description}
+                onChange={(e) => setForm({ ...form, description: e.target.value })}
+                placeholder="Optional description"
+                rows={3}
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label htmlFor="startDate">Start Month *</Label>
+                <Input
+                  id="startDate"
+                  value={form.startDate}
+                  onChange={(e) => setForm({ ...form, startDate: e.target.value })}
+                  placeholder="YYYY-MM"
+                  pattern="\d{4}-\d{2}"
+                  required
+                />
+                <p className="text-xs text-muted-foreground mt-1">Format: YYYY-MM</p>
+              </div>
+              <div>
+                <Label htmlFor="endDate">End Month *</Label>
+                <Input
+                  id="endDate"
+                  value={form.endDate}
+                  onChange={(e) => setForm({ ...form, endDate: e.target.value })}
+                  placeholder="YYYY-MM"
+                  pattern="\d{4}-\d{2}"
+                  required
+                />
+              </div>
+            </div>
+
+            <div>
+              <Label htmlFor="currency">Currency</Label>
+              <Input
+                id="currency"
+                value={form.currency}
+                onChange={(e) => setForm({ ...form, currency: e.target.value })}
+                placeholder="IDR"
+              />
+            </div>
+
+            {error && (
+              <div className="text-sm text-destructive bg-destructive/10 rounded p-3">{error}</div>
+            )}
+
+            <div className="flex gap-3 pt-2">
+              <Button type="submit" disabled={submitting} className="flex-1">
+                {submitting ? 'Creating…' : 'Create Forecast'}
+              </Button>
+              <Button asChild variant="outline">
+                <Link href="/forecasts">Cancel</Link>
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/forecasts/StreamTree.tsx
+++ b/src/components/forecasts/StreamTree.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronDown, ChevronRight, Plus, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+export interface ForecastStream {
+  id: number;
+  name: string;
+  type: 'revenue' | 'expense';
+  order: number;
+}
+
+export interface ForecastItem {
+  id: number;
+  streamId: number;
+  name: string;
+  order: number;
+}
+
+interface StreamTreeProps {
+  streams: ForecastStream[];
+  items: ForecastItem[];
+  selectedItemId?: number;
+  onSelectItem: (itemId: number) => void;
+  onAddStream?: () => void;
+  onAddItem?: (streamId: number) => void;
+  onDeleteStream?: (streamId: number) => void;
+  onDeleteItem?: (itemId: number) => void;
+}
+
+export function StreamTree({
+  streams,
+  items,
+  selectedItemId,
+  onSelectItem,
+  onAddStream,
+  onAddItem,
+  onDeleteStream,
+  onDeleteItem,
+}: StreamTreeProps) {
+  const [collapsed, setCollapsed] = useState<Set<number>>(new Set());
+
+  function toggleCollapse(streamId: number) {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(streamId)) next.delete(streamId);
+      else next.add(streamId);
+      return next;
+    });
+  }
+
+  return (
+    <div className="space-y-2">
+      {streams
+        .sort((a, b) => a.order - b.order)
+        .map((stream) => {
+          const streamItems = items.filter((i) => i.streamId === stream.id).sort((a, b) => a.order - b.order);
+          const isCollapsed = collapsed.has(stream.id);
+
+          return (
+            <div key={stream.id} className="rounded-md border">
+              {/* Stream header */}
+              <div className="flex items-center justify-between px-3 py-2 bg-muted/50 rounded-t-md">
+                <button
+                  className="flex items-center gap-2 flex-1 text-left text-sm font-medium"
+                  onClick={() => toggleCollapse(stream.id)}
+                >
+                  {isCollapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+                  <span>{stream.name}</span>
+                  <span className={cn(
+                    'text-xs px-1.5 py-0.5 rounded-full',
+                    stream.type === 'revenue'
+                      ? 'bg-green-100 text-green-700'
+                      : 'bg-red-100 text-red-700'
+                  )}>
+                    {stream.type}
+                  </span>
+                </button>
+                <div className="flex gap-1">
+                  {onAddItem && (
+                    <Button size="icon" variant="ghost" className="h-6 w-6" onClick={() => onAddItem(stream.id)}>
+                      <Plus className="h-3 w-3" />
+                    </Button>
+                  )}
+                  {onDeleteStream && (
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="h-6 w-6 text-destructive"
+                      onClick={() => onDeleteStream(stream.id)}
+                    >
+                      <Trash2 className="h-3 w-3" />
+                    </Button>
+                  )}
+                </div>
+              </div>
+
+              {/* Items */}
+              {!isCollapsed && (
+                <div className="divide-y">
+                  {streamItems.map((item) => (
+                    <div
+                      key={item.id}
+                      role="button"
+                      tabIndex={0}
+                      className={cn(
+                        'flex items-center justify-between w-full px-6 py-2 text-sm text-left hover:bg-accent transition-colors cursor-pointer',
+                        selectedItemId === item.id && 'bg-accent font-medium'
+                      )}
+                      onClick={() => onSelectItem(item.id)}
+                      onKeyDown={(e) => e.key === 'Enter' && onSelectItem(item.id)}
+                    >
+                      <span>{item.name}</span>
+                      {onDeleteItem && (
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="h-5 w-5 text-destructive opacity-0 group-hover:opacity-100"
+                          onClick={(e) => { e.stopPropagation(); onDeleteItem(item.id); }}
+                        >
+                          <Trash2 className="h-3 w-3" />
+                        </Button>
+                      )}
+                    </div>
+                  ))}
+                  {streamItems.length === 0 && (
+                    <p className="px-6 py-2 text-xs text-muted-foreground">No items</p>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      {onAddStream && (
+        <Button variant="outline" size="sm" className="w-full" onClick={onAddStream}>
+          <Plus className="h-4 w-4 mr-2" /> Add Stream
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/forecasts/VarianceCell.tsx
+++ b/src/components/forecasts/VarianceCell.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
+
+export type TrackingStatus = 'on_track' | 'at_risk' | 'off_track';
+
+interface VarianceCellProps {
+  variance: number;
+  variancePct: number | null;
+  status?: TrackingStatus;
+  currency?: string;
+}
+
+const statusConfig: Record<TrackingStatus, { label: string; className: string }> = {
+  on_track: { label: 'On Track', className: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' },
+  at_risk: { label: 'At Risk', className: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200' },
+  off_track: { label: 'Off Track', className: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200' },
+};
+
+export function VarianceCell({ variance, variancePct, status, currency = 'IDR' }: VarianceCellProps) {
+  const isPositive = variance >= 0;
+  const formatted = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: 0,
+  }).format(Math.abs(variance));
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <span className={cn('text-sm font-medium', isPositive ? 'text-green-600' : 'text-red-600')}>
+        {isPositive ? '+' : '-'}{formatted}
+      </span>
+      {variancePct !== null && (
+        <span className={cn('text-xs', isPositive ? 'text-green-500' : 'text-red-500')}>
+          {isPositive ? '+' : ''}{variancePct.toFixed(1)}%
+        </span>
+      )}
+      {status && (
+        <Badge className={cn('text-xs px-1.5 py-0.5', statusConfig[status].className)} variant="outline">
+          {statusConfig[status].label}
+        </Badge>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -11,10 +11,16 @@ import {
 import { Moon, Sun, User, LogOut } from 'lucide-react';
 import { useSession, signOut } from 'next-auth/react';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 
 export function Header() {
   const { theme, setTheme } = useTheme();
   const { data: session } = useSession();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   return (
     <header className="sticky top-0 z-30 flex h-16 items-center justify-between border-b bg-background px-4">
@@ -25,29 +31,31 @@ export function Header() {
       <div className="flex-1 md:flex-none"></div>
       
       <div className="flex items-center gap-4">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="icon" className="rounded-full">
-              {theme === 'dark' ? (
-                <Moon className="h-4 w-4" />
-              ) : (
-                <Sun className="h-4 w-4" />
-              )}
-              <span className="sr-only">Toggle theme</span>
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem onClick={() => setTheme('light')}>
-              Light
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => setTheme('dark')}>
-              Dark
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => setTheme('system')}>
-              System
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        {mounted && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="icon" className="rounded-full">
+                {theme === 'dark' ? (
+                  <Moon className="h-4 w-4" />
+                ) : (
+                  <Sun className="h-4 w-4" />
+                )}
+                <span className="sr-only">Toggle theme</span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => setTheme('light')}>
+                Light
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setTheme('dark')}>
+                Dark
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setTheme('system')}>
+                System
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
 
         {session ? (
           <DropdownMenu>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -15,6 +15,7 @@ import {
   Tags,
   FolderTree,
   Store,
+  TrendingUp,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import Image from 'next/image';
@@ -33,6 +34,7 @@ const navItems = [
   { label: 'Expenses', icon: Receipt, href: '/expenses', group: 'Transactions' },
   { label: 'Recurring', icon: RefreshCw, href: '/recurring-transactions', group: 'Transactions' },
   // { label: 'Reports', icon: LineChart, href: '/reports' },
+  { label: 'Forecasts', icon: TrendingUp, href: '/forecasts', group: 'Planning' },
   { label: 'Settings', icon: Settings, href: '/settings', group: 'Settings' },
 ];
 
@@ -74,7 +76,7 @@ export function Sidebar() {
                   href={item.href}
                   className={cn(
                     'flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-colors',
-                    pathname === item.href
+                    pathname === item.href || (item.href !== '/dashboard' && pathname.startsWith(item.href))
                       ? 'bg-primary text-primary-foreground'
                       : 'hover:bg-accent'
                   )}

--- a/src/lib/db/migrations/0018_striped_machine_man.sql
+++ b/src/lib/db/migrations/0018_striped_machine_man.sql
@@ -1,0 +1,93 @@
+CREATE TYPE "public"."forecast_scope_type" AS ENUM('global', 'stream', 'item');--> statement-breakpoint
+CREATE TYPE "public"."forecast_stream_type" AS ENUM('revenue', 'expense');--> statement-breakpoint
+CREATE TABLE "forecast_growth_rules" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"forecast_id" integer NOT NULL,
+	"scope_type" "forecast_scope_type" NOT NULL,
+	"scope_id" integer,
+	"year" integer NOT NULL,
+	"growth_rate" numeric(6, 4) NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "forecast_items" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"forecast_id" integer NOT NULL,
+	"stream_id" integer NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"description" text,
+	"order" integer DEFAULT 0 NOT NULL,
+	"income_category_id" integer,
+	"expense_category_id" integer,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "forecast_period_values" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"forecast_id" integer NOT NULL,
+	"item_id" integer NOT NULL,
+	"period" varchar(7) NOT NULL,
+	"amount" numeric(15, 2) DEFAULT '0' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "forecast_seasonality_weights" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"forecast_id" integer NOT NULL,
+	"scope_type" "forecast_scope_type" NOT NULL,
+	"scope_id" integer,
+	"month" integer NOT NULL,
+	"weight" numeric(6, 4) NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "forecast_streams" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"forecast_id" integer NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"type" "forecast_stream_type" NOT NULL,
+	"order" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "forecast_variables" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"forecast_id" integer NOT NULL,
+	"key" varchar(100) NOT NULL,
+	"value" numeric(15, 4) NOT NULL,
+	"description" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "forecasts" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"company_id" integer NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"description" text,
+	"start_date" varchar(7) NOT NULL,
+	"end_date" varchar(7) NOT NULL,
+	"currency" varchar(10) DEFAULT 'IDR' NOT NULL,
+	"soft_delete" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "forecast_growth_rules" ADD CONSTRAINT "forecast_growth_rules_forecast_id_forecasts_id_fk" FOREIGN KEY ("forecast_id") REFERENCES "public"."forecasts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "forecast_items" ADD CONSTRAINT "forecast_items_forecast_id_forecasts_id_fk" FOREIGN KEY ("forecast_id") REFERENCES "public"."forecasts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "forecast_items" ADD CONSTRAINT "forecast_items_stream_id_forecast_streams_id_fk" FOREIGN KEY ("stream_id") REFERENCES "public"."forecast_streams"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "forecast_items" ADD CONSTRAINT "forecast_items_income_category_id_income_categories_id_fk" FOREIGN KEY ("income_category_id") REFERENCES "public"."income_categories"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "forecast_items" ADD CONSTRAINT "forecast_items_expense_category_id_expense_categories_id_fk" FOREIGN KEY ("expense_category_id") REFERENCES "public"."expense_categories"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "forecast_period_values" ADD CONSTRAINT "forecast_period_values_forecast_id_forecasts_id_fk" FOREIGN KEY ("forecast_id") REFERENCES "public"."forecasts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "forecast_period_values" ADD CONSTRAINT "forecast_period_values_item_id_forecast_items_id_fk" FOREIGN KEY ("item_id") REFERENCES "public"."forecast_items"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "forecast_seasonality_weights" ADD CONSTRAINT "forecast_seasonality_weights_forecast_id_forecasts_id_fk" FOREIGN KEY ("forecast_id") REFERENCES "public"."forecasts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "forecast_streams" ADD CONSTRAINT "forecast_streams_forecast_id_forecasts_id_fk" FOREIGN KEY ("forecast_id") REFERENCES "public"."forecasts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "forecast_variables" ADD CONSTRAINT "forecast_variables_forecast_id_forecasts_id_fk" FOREIGN KEY ("forecast_id") REFERENCES "public"."forecasts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "forecasts" ADD CONSTRAINT "forecasts_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "forecast_period_values_item_period_idx" ON "forecast_period_values" USING btree ("item_id","period");--> statement-breakpoint
+CREATE UNIQUE INDEX "forecast_seasonality_weights_unique_idx" ON "forecast_seasonality_weights" USING btree ("forecast_id","scope_type","scope_id","month");

--- a/src/lib/db/migrations/meta/0018_snapshot.json
+++ b/src/lib/db/migrations/meta/0018_snapshot.json
@@ -1,0 +1,3061 @@
+{
+  "id": "8c8cc104-b9fa-4ed6-9fd4-b5241b81f2f0",
+  "prevId": "485809df-7969-4242-b890-503cffea6683",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'IDR'"
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "initial_balance": {
+          "name": "initial_balance",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "current_balance": {
+          "name": "current_balance",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "soft_delete": {
+          "name": "soft_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_company_id_companies_id_fk": {
+          "name": "accounts_company_id_companies_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_tokens_company_id_companies_id_fk": {
+          "name": "api_tokens_company_id_companies_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_prefix_unique": {
+          "name": "api_tokens_token_prefix_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_prefix"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.client_login_tokens": {
+      "name": "client_login_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "client_login_tokens_token_idx": {
+          "name": "client_login_tokens_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "client_login_tokens_client_id_clients_id_fk": {
+          "name": "client_login_tokens_client_id_clients_id_fk",
+          "tableFrom": "client_login_tokens",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.client_users": {
+      "name": "client_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "soft_delete": {
+          "name": "soft_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "client_users_email_idx": {
+          "name": "client_users_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_users_client_id_idx": {
+          "name": "client_users_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "client_users_client_id_clients_id_fk": {
+          "name": "client_users_client_id_clients_id_fk",
+          "tableFrom": "client_users",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "soft_delete": {
+          "name": "soft_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "clients_company_id_idx": {
+          "name": "clients_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clients_company_id_companies_id_fk": {
+          "name": "clients_company_id_companies_id_fk",
+          "tableFrom": "clients",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.companies": {
+      "name": "companies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_currency": {
+          "name": "default_currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'IDR'"
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bank_account": {
+          "name": "bank_account",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_number": {
+          "name": "tax_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "soft_delete": {
+          "name": "soft_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.company_invitations": {
+      "name": "company_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'staff'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "company_invitations_token_idx": {
+          "name": "company_invitations_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "company_invitations_email_company_idx": {
+          "name": "company_invitations_email_company_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "company_invitations_company_id_companies_id_fk": {
+          "name": "company_invitations_company_id_companies_id_fk",
+          "tableFrom": "company_invitations",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.expense_categories": {
+      "name": "expense_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "soft_delete": {
+          "name": "soft_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "expense_categories_company_id_companies_id_fk": {
+          "name": "expense_categories_company_id_companies_id_fk",
+          "tableFrom": "expense_categories",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.expenses": {
+      "name": "expenses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vendor_id": {
+          "name": "vendor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'IDR'"
+        },
+        "expense_date": {
+          "name": "expense_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "recurring": {
+          "name": "recurring",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "next_due_date": {
+          "name": "next_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "soft_delete": {
+          "name": "soft_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "expenses_company_id_companies_id_fk": {
+          "name": "expenses_company_id_companies_id_fk",
+          "tableFrom": "expenses",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "expenses_category_id_expense_categories_id_fk": {
+          "name": "expenses_category_id_expense_categories_id_fk",
+          "tableFrom": "expenses",
+          "tableTo": "expense_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "expenses_vendor_id_vendors_id_fk": {
+          "name": "expenses_vendor_id_vendors_id_fk",
+          "tableFrom": "expenses",
+          "tableTo": "vendors",
+          "columnsFrom": [
+            "vendor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forecast_growth_rules": {
+      "name": "forecast_growth_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "forecast_id": {
+          "name": "forecast_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "forecast_scope_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "growth_rate": {
+          "name": "growth_rate",
+          "type": "numeric(6, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "forecast_growth_rules_forecast_id_forecasts_id_fk": {
+          "name": "forecast_growth_rules_forecast_id_forecasts_id_fk",
+          "tableFrom": "forecast_growth_rules",
+          "tableTo": "forecasts",
+          "columnsFrom": [
+            "forecast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forecast_items": {
+      "name": "forecast_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "forecast_id": {
+          "name": "forecast_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stream_id": {
+          "name": "stream_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "income_category_id": {
+          "name": "income_category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expense_category_id": {
+          "name": "expense_category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "forecast_items_forecast_id_forecasts_id_fk": {
+          "name": "forecast_items_forecast_id_forecasts_id_fk",
+          "tableFrom": "forecast_items",
+          "tableTo": "forecasts",
+          "columnsFrom": [
+            "forecast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "forecast_items_stream_id_forecast_streams_id_fk": {
+          "name": "forecast_items_stream_id_forecast_streams_id_fk",
+          "tableFrom": "forecast_items",
+          "tableTo": "forecast_streams",
+          "columnsFrom": [
+            "stream_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "forecast_items_income_category_id_income_categories_id_fk": {
+          "name": "forecast_items_income_category_id_income_categories_id_fk",
+          "tableFrom": "forecast_items",
+          "tableTo": "income_categories",
+          "columnsFrom": [
+            "income_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "forecast_items_expense_category_id_expense_categories_id_fk": {
+          "name": "forecast_items_expense_category_id_expense_categories_id_fk",
+          "tableFrom": "forecast_items",
+          "tableTo": "expense_categories",
+          "columnsFrom": [
+            "expense_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forecast_period_values": {
+      "name": "forecast_period_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "forecast_id": {
+          "name": "forecast_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "forecast_period_values_item_period_idx": {
+          "name": "forecast_period_values_item_period_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forecast_period_values_forecast_id_forecasts_id_fk": {
+          "name": "forecast_period_values_forecast_id_forecasts_id_fk",
+          "tableFrom": "forecast_period_values",
+          "tableTo": "forecasts",
+          "columnsFrom": [
+            "forecast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "forecast_period_values_item_id_forecast_items_id_fk": {
+          "name": "forecast_period_values_item_id_forecast_items_id_fk",
+          "tableFrom": "forecast_period_values",
+          "tableTo": "forecast_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forecast_seasonality_weights": {
+      "name": "forecast_seasonality_weights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "forecast_id": {
+          "name": "forecast_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "forecast_scope_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "month": {
+          "name": "month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "numeric(6, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "forecast_seasonality_weights_unique_idx": {
+          "name": "forecast_seasonality_weights_unique_idx",
+          "columns": [
+            {
+              "expression": "forecast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "forecast_seasonality_weights_forecast_id_forecasts_id_fk": {
+          "name": "forecast_seasonality_weights_forecast_id_forecasts_id_fk",
+          "tableFrom": "forecast_seasonality_weights",
+          "tableTo": "forecasts",
+          "columnsFrom": [
+            "forecast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forecast_streams": {
+      "name": "forecast_streams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "forecast_id": {
+          "name": "forecast_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "forecast_stream_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "forecast_streams_forecast_id_forecasts_id_fk": {
+          "name": "forecast_streams_forecast_id_forecasts_id_fk",
+          "tableFrom": "forecast_streams",
+          "tableTo": "forecasts",
+          "columnsFrom": [
+            "forecast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forecast_variables": {
+      "name": "forecast_variables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "forecast_id": {
+          "name": "forecast_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric(15, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "forecast_variables_forecast_id_forecasts_id_fk": {
+          "name": "forecast_variables_forecast_id_forecasts_id_fk",
+          "tableFrom": "forecast_variables",
+          "tableTo": "forecasts",
+          "columnsFrom": [
+            "forecast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.forecasts": {
+      "name": "forecasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'IDR'"
+        },
+        "soft_delete": {
+          "name": "soft_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "forecasts_company_id_companies_id_fk": {
+          "name": "forecasts_company_id_companies_id_fk",
+          "tableFrom": "forecasts",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.income": {
+      "name": "income",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'IDR'"
+        },
+        "income_date": {
+          "name": "income_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurring": {
+          "name": "recurring",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "next_due_date": {
+          "name": "next_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "soft_delete": {
+          "name": "soft_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "income_company_id_companies_id_fk": {
+          "name": "income_company_id_companies_id_fk",
+          "tableFrom": "income",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "income_category_id_income_categories_id_fk": {
+          "name": "income_category_id_income_categories_id_fk",
+          "tableFrom": "income",
+          "tableTo": "income_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "income_client_id_clients_id_fk": {
+          "name": "income_client_id_clients_id_fk",
+          "tableFrom": "income",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "income_invoice_id_invoices_id_fk": {
+          "name": "income_invoice_id_invoices_id_fk",
+          "tableFrom": "income",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.income_categories": {
+      "name": "income_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "soft_delete": {
+          "name": "soft_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "income_categories_company_id_companies_id_fk": {
+          "name": "income_categories_company_id_companies_id_fk",
+          "tableFrom": "income_categories",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "tax_rate": {
+          "name": "tax_rate",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'IDR'"
+        },
+        "xendit_invoice_id": {
+          "name": "xendit_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xendit_invoice_url": {
+          "name": "xendit_invoice_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurring": {
+          "name": "recurring",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "next_due_date": {
+          "name": "next_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soft_delete": {
+          "name": "soft_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoices_company_id_companies_id_fk": {
+          "name": "invoices_company_id_companies_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'IDR'"
+        },
+        "payment_date": {
+          "name": "payment_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_processor_reference": {
+          "name": "payment_processor_reference",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "soft_delete": {
+          "name": "soft_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payments_company_id_companies_id_fk": {
+          "name": "payments_company_id_companies_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_client_id_clients_id_fk": {
+          "name": "payments_client_id_clients_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_transaction_id_transactions_id_fk": {
+          "name": "payments_transaction_id_transactions_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_items": {
+      "name": "quote_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quote_items_quote_id_quotes_id_fk": {
+          "name": "quote_items_quote_id_quotes_id_fk",
+          "tableFrom": "quote_items",
+          "tableTo": "quotes",
+          "columnsFrom": [
+            "quote_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quotes": {
+      "name": "quotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quote_number": {
+          "name": "quote_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "quote_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiry_date": {
+          "name": "expiry_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax": {
+          "name": "tax",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "tax_rate": {
+          "name": "tax_rate",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soft_delete": {
+          "name": "soft_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "converted_to_invoice_id": {
+          "name": "converted_to_invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quotes_company_id_companies_id_fk": {
+          "name": "quotes_company_id_companies_id_fk",
+          "tableFrom": "quotes",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quotes_client_id_clients_id_fk": {
+          "name": "quotes_client_id_clients_id_fk",
+          "tableFrom": "quotes",
+          "tableTo": "clients",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "quotes_converted_to_invoice_id_invoices_id_fk": {
+          "name": "quotes_converted_to_invoice_id_invoices_id_fk",
+          "tableFrom": "quotes",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "converted_to_invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test": {
+      "name": "test",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'IDR'"
+        },
+        "transaction_date": {
+          "name": "transaction_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_invoice_id": {
+          "name": "related_invoice_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_expense_id": {
+          "name": "related_expense_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_income_id": {
+          "name": "related_income_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciled": {
+          "name": "reconciled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "soft_delete": {
+          "name": "soft_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transactions_company_id_companies_id_fk": {
+          "name": "transactions_company_id_companies_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_related_invoice_id_invoices_id_fk": {
+          "name": "transactions_related_invoice_id_invoices_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "related_invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_related_expense_id_expenses_id_fk": {
+          "name": "transactions_related_expense_id_expenses_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "expenses",
+          "columnsFrom": [
+            "related_expense_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_related_income_id_income_id_fk": {
+          "name": "transactions_related_income_id_income_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "income",
+          "columnsFrom": [
+            "related_income_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'staff'"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "soft_delete": {
+          "name": "soft_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "email_idx": {
+          "name": "email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_company_id_companies_id_fk": {
+          "name": "users_company_id_companies_id_fk",
+          "tableFrom": "users",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vendors": {
+      "name": "vendors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "soft_delete": {
+          "name": "soft_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vendors_company_id_companies_id_fk": {
+          "name": "vendors_company_id_companies_id_fk",
+          "tableFrom": "vendors",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "bank",
+        "credit_card",
+        "cash"
+      ]
+    },
+    "public.forecast_scope_type": {
+      "name": "forecast_scope_type",
+      "schema": "public",
+      "values": [
+        "global",
+        "stream",
+        "item"
+      ]
+    },
+    "public.forecast_stream_type": {
+      "name": "forecast_stream_type",
+      "schema": "public",
+      "values": [
+        "revenue",
+        "expense"
+      ]
+    },
+    "public.invitation_status": {
+      "name": "invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "expired",
+        "cancelled"
+      ]
+    },
+    "public.invoice_status": {
+      "name": "invoice_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "sent",
+        "paid",
+        "overdue",
+        "cancelled"
+      ]
+    },
+    "public.payment_method": {
+      "name": "payment_method",
+      "schema": "public",
+      "values": [
+        "card",
+        "bank_transfer",
+        "cash",
+        "other"
+      ]
+    },
+    "public.payment_status": {
+      "name": "payment_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.quote_status": {
+      "name": "quote_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "sent",
+        "accepted",
+        "rejected",
+        "expired"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "staff",
+        "accountant"
+      ]
+    },
+    "public.transaction_type": {
+      "name": "transaction_type",
+      "schema": "public",
+      "values": [
+        "debit",
+        "credit"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/lib/db/migrations/meta/_journal.json
+++ b/src/lib/db/migrations/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1746957956599,
       "tag": "0017_acoustic_sumo",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1773782889755,
+      "tag": "0018_striped_machine_man",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -619,3 +619,141 @@ export const apiTokensRelations = relations(apiTokens, ({ one }) => ({
     references: [companies.id],
   }),
 }));
+
+// ─── Forecasting & Budget Tracking ───────────────────────────────────────────
+
+// Enums
+export const forecastStreamTypeEnum = pgEnum('forecast_stream_type', ['revenue', 'expense']);
+export const forecastScopeTypeEnum = pgEnum('forecast_scope_type', ['global', 'stream', 'item']);
+
+// Forecasts – top-level planning container
+export const forecasts = pgTable('forecasts', {
+  id: serial('id').primaryKey(),
+  companyId: integer('company_id').notNull().references(() => companies.id),
+  name: varchar('name', { length: 255 }).notNull(),
+  description: text('description'),
+  startDate: varchar('start_date', { length: 7 }).notNull(), // YYYY-MM
+  endDate: varchar('end_date', { length: 7 }).notNull(),     // YYYY-MM
+  currency: varchar('currency', { length: 10 }).default('IDR').notNull(),
+  softDelete: boolean('soft_delete').default(false).notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+
+// Forecast Streams – revenue or expense groupings
+export const forecastStreams = pgTable('forecast_streams', {
+  id: serial('id').primaryKey(),
+  forecastId: integer('forecast_id').notNull().references(() => forecasts.id),
+  name: varchar('name', { length: 255 }).notNull(),
+  type: forecastStreamTypeEnum('type').notNull(),
+  order: integer('order').default(0).notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+
+// Forecast Items – individual line items within a stream
+export const forecastItems = pgTable('forecast_items', {
+  id: serial('id').primaryKey(),
+  forecastId: integer('forecast_id').notNull().references(() => forecasts.id),
+  streamId: integer('stream_id').notNull().references(() => forecastStreams.id),
+  name: varchar('name', { length: 255 }).notNull(),
+  description: text('description'),
+  order: integer('order').default(0).notNull(),
+  incomeCategoryId: integer('income_category_id').references(() => incomeCategories.id),
+  expenseCategoryId: integer('expense_category_id').references(() => expenseCategories.id),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+
+// Forecast Period Values – monthly amounts per item
+export const forecastPeriodValues = pgTable('forecast_period_values', {
+  id: serial('id').primaryKey(),
+  forecastId: integer('forecast_id').notNull().references(() => forecasts.id),
+  itemId: integer('item_id').notNull().references(() => forecastItems.id),
+  period: varchar('period', { length: 7 }).notNull(), // YYYY-MM
+  amount: decimal('amount', { precision: 15, scale: 2 }).notNull().default('0'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (table) => ({
+  itemPeriodIdx: uniqueIndex('forecast_period_values_item_period_idx').on(table.itemId, table.period),
+}));
+
+// Forecast Variables – named constants usable in descriptions/assumptions
+export const forecastVariables = pgTable('forecast_variables', {
+  id: serial('id').primaryKey(),
+  forecastId: integer('forecast_id').notNull().references(() => forecasts.id),
+  key: varchar('key', { length: 100 }).notNull(),
+  value: decimal('value', { precision: 15, scale: 4 }).notNull(),
+  description: text('description'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+
+// Forecast Growth Rules – YoY growth rates per scope
+export const forecastGrowthRules = pgTable('forecast_growth_rules', {
+  id: serial('id').primaryKey(),
+  forecastId: integer('forecast_id').notNull().references(() => forecasts.id),
+  scopeType: forecastScopeTypeEnum('scope_type').notNull(),
+  scopeId: integer('scope_id'),   // null when scopeType = 'global'
+  year: integer('year').notNull(),
+  growthRate: decimal('growth_rate', { precision: 6, scale: 4 }).notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+
+// Forecast Seasonality Weights – monthly distribution weights
+export const forecastSeasonalityWeights = pgTable('forecast_seasonality_weights', {
+  id: serial('id').primaryKey(),
+  forecastId: integer('forecast_id').notNull().references(() => forecasts.id),
+  scopeType: forecastScopeTypeEnum('scope_type').notNull(),
+  scopeId: integer('scope_id'),   // null when scopeType = 'global'
+  month: integer('month').notNull(), // 1–12
+  weight: decimal('weight', { precision: 6, scale: 4 }).notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+}, (table) => ({
+  uniqueWeight: uniqueIndex('forecast_seasonality_weights_unique_idx').on(
+    table.forecastId, table.scopeType, table.scopeId, table.month
+  ),
+}));
+
+// Relations
+export const forecastsRelations = relations(forecasts, ({ one, many }) => ({
+  company: one(companies, { fields: [forecasts.companyId], references: [companies.id] }),
+  streams: many(forecastStreams),
+  items: many(forecastItems),
+  periodValues: many(forecastPeriodValues),
+  variables: many(forecastVariables),
+  growthRules: many(forecastGrowthRules),
+  seasonalityWeights: many(forecastSeasonalityWeights),
+}));
+
+export const forecastStreamsRelations = relations(forecastStreams, ({ one, many }) => ({
+  forecast: one(forecasts, { fields: [forecastStreams.forecastId], references: [forecasts.id] }),
+  items: many(forecastItems),
+}));
+
+export const forecastItemsRelations = relations(forecastItems, ({ one, many }) => ({
+  forecast: one(forecasts, { fields: [forecastItems.forecastId], references: [forecasts.id] }),
+  stream: one(forecastStreams, { fields: [forecastItems.streamId], references: [forecastStreams.id] }),
+  incomeCategory: one(incomeCategories, { fields: [forecastItems.incomeCategoryId], references: [incomeCategories.id] }),
+  expenseCategory: one(expenseCategories, { fields: [forecastItems.expenseCategoryId], references: [expenseCategories.id] }),
+  periodValues: many(forecastPeriodValues),
+}));
+
+export const forecastPeriodValuesRelations = relations(forecastPeriodValues, ({ one }) => ({
+  forecast: one(forecasts, { fields: [forecastPeriodValues.forecastId], references: [forecasts.id] }),
+  item: one(forecastItems, { fields: [forecastPeriodValues.itemId], references: [forecastItems.id] }),
+}));
+
+export const forecastVariablesRelations = relations(forecastVariables, ({ one }) => ({
+  forecast: one(forecasts, { fields: [forecastVariables.forecastId], references: [forecasts.id] }),
+}));
+
+export const forecastGrowthRulesRelations = relations(forecastGrowthRules, ({ one }) => ({
+  forecast: one(forecasts, { fields: [forecastGrowthRules.forecastId], references: [forecasts.id] }),
+}));
+
+export const forecastSeasonalityWeightsRelations = relations(forecastSeasonalityWeights, ({ one }) => ({
+  forecast: one(forecasts, { fields: [forecastSeasonalityWeights.forecastId], references: [forecasts.id] }),
+}));

--- a/src/lib/forecasts/assumptions.ts
+++ b/src/lib/forecasts/assumptions.ts
@@ -1,0 +1,172 @@
+import { db } from '@/lib/db';
+import {
+  forecastItems,
+  forecastPeriodValues,
+  forecastStreams,
+  forecastGrowthRules,
+  forecastSeasonalityWeights,
+} from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
+
+/**
+ * Apply YoY growth rules and seasonality weights to generate forecast_period_values
+ * for all years beyond the base year (the earliest year in the forecast's startDate).
+ */
+export async function applyAssumptions(forecastId: number, companyId: number): Promise<void> {
+  // Load all items for this forecast
+  const items = await db
+    .select()
+    .from(forecastItems)
+    .where(eq(forecastItems.forecastId, forecastId));
+
+  if (items.length === 0) return;
+
+  // Load streams for scope lookups
+  const streams = await db
+    .select()
+    .from(forecastStreams)
+    .where(eq(forecastStreams.forecastId, forecastId));
+
+  // Load growth rules
+  const growthRules = await db
+    .select()
+    .from(forecastGrowthRules)
+    .where(eq(forecastGrowthRules.forecastId, forecastId));
+
+  // Load seasonality weights
+  const seasonalityWeights = await db
+    .select()
+    .from(forecastSeasonalityWeights)
+    .where(eq(forecastSeasonalityWeights.forecastId, forecastId));
+
+  // Load existing period values
+  const existingValues = await db
+    .select()
+    .from(forecastPeriodValues)
+    .where(eq(forecastPeriodValues.forecastId, forecastId));
+
+  // Build lookup: itemId → period → amount
+  const baseValues: Record<number, Record<string, number>> = {};
+  for (const pv of existingValues) {
+    if (!baseValues[pv.itemId]) baseValues[pv.itemId] = {};
+    baseValues[pv.itemId][pv.period] = Number(pv.amount);
+  }
+
+  // Determine base year (earliest year present in period values)
+  const allPeriods = existingValues.map((v) => v.period);
+  if (allPeriods.length === 0) return;
+
+  const years = [...new Set(allPeriods.map((p) => parseInt(p.substring(0, 4))))].sort();
+  const baseYear = years[0];
+  const forecastYears = years.filter((y) => y > baseYear);
+
+  // Helper: get growth rate for a specific item + year
+  function getGrowthRate(itemId: number, year: number): number {
+    const item = items.find((i) => i.id === itemId);
+    if (!item) return 0;
+
+    // Item-level rule (most specific)
+    const itemRule = growthRules.find(
+      (r) => r.scopeType === 'item' && r.scopeId === itemId && r.year === year
+    );
+    if (itemRule) return Number(itemRule.growthRate);
+
+    // Stream-level rule
+    const streamRule = growthRules.find(
+      (r) => r.scopeType === 'stream' && r.scopeId === item.streamId && r.year === year
+    );
+    if (streamRule) return Number(streamRule.growthRate);
+
+    // Global rule
+    const globalRule = growthRules.find(
+      (r) => r.scopeType === 'global' && r.year === year
+    );
+    if (globalRule) return Number(globalRule.growthRate);
+
+    return 0;
+  }
+
+  // Helper: get seasonality weights for an item (12 months)
+  function getSeasonalityWeights(itemId: number): number[] {
+    // Try item-level weights
+    const itemWeights = seasonalityWeights.filter(
+      (w) => w.scopeType === 'item' && w.scopeId === itemId
+    );
+    if (itemWeights.length === 12) {
+      const arr = new Array(12).fill(0);
+      for (const w of itemWeights) arr[w.month - 1] = Number(w.weight);
+      return arr;
+    }
+
+    // Try global weights
+    const globalWeights = seasonalityWeights.filter((w) => w.scopeType === 'global');
+    if (globalWeights.length === 12) {
+      const arr = new Array(12).fill(0);
+      for (const w of globalWeights) arr[w.month - 1] = Number(w.weight);
+      return arr;
+    }
+
+    // Equal distribution
+    return new Array(12).fill(1 / 12);
+  }
+
+  // Compute and upsert values for non-base years
+  const upsertRows: Array<{
+    forecastId: number;
+    itemId: number;
+    period: string;
+    amount: string;
+  }> = [];
+
+  for (const item of items) {
+    const itemBaseValues = baseValues[item.id] ?? {};
+
+    // Sum base year monthly values to get annual total
+    const baseAnnual = Object.entries(itemBaseValues)
+      .filter(([period]) => parseInt(period.substring(0, 4)) === baseYear)
+      .reduce((sum, [, amt]) => sum + amt, 0);
+
+    for (const year of forecastYears) {
+      const growthRate = getGrowthRate(item.id, year);
+      const prevYear = year - 1;
+
+      // Get previous year annual total (already computed or base)
+      let prevAnnual: number;
+      if (prevYear === baseYear) {
+        prevAnnual = baseAnnual;
+      } else {
+        prevAnnual = Object.entries(itemBaseValues)
+          .filter(([period]) => parseInt(period.substring(0, 4)) === prevYear)
+          .reduce((sum, [, amt]) => sum + amt, 0);
+        // Use computed rows if available
+        const computed = upsertRows
+          .filter((r) => r.itemId === item.id && r.period.startsWith(String(prevYear)))
+          .reduce((sum, r) => sum + Number(r.amount), 0);
+        if (computed > 0) prevAnnual = computed;
+      }
+
+      const annualTotal = prevAnnual * (1 + growthRate);
+      const weights = getSeasonalityWeights(item.id);
+      const weightSum = weights.reduce((s, w) => s + w, 0) || 1;
+
+      for (let month = 1; month <= 12; month++) {
+        const period = `${year}-${String(month).padStart(2, '0')}`;
+        const monthlyAmount = (annualTotal * (weights[month - 1] / weightSum)).toFixed(2);
+        upsertRows.push({ forecastId, itemId: item.id, period, amount: monthlyAmount });
+      }
+    }
+  }
+
+  // Bulk upsert
+  if (upsertRows.length === 0) return;
+
+  for (const row of upsertRows) {
+    await db
+      .insert(forecastPeriodValues)
+      .values({ ...row, createdAt: new Date(), updatedAt: new Date() })
+      .onConflictDoUpdate({
+        target: [forecastPeriodValues.itemId, forecastPeriodValues.period],
+        set: { amount: row.amount, updatedAt: new Date() },
+      });
+  }
+}

--- a/src/lib/forecasts/comparison.ts
+++ b/src/lib/forecasts/comparison.ts
@@ -1,0 +1,146 @@
+import { db } from '@/lib/db';
+import { forecastItems, forecastPeriodValues, forecastStreams, income, expenses } from '@/lib/db/schema';
+import { and, eq, gte, lte, sql, sum } from 'drizzle-orm';
+
+export interface ComparisonRow {
+  itemId: number;
+  itemName: string;
+  streamType: 'revenue' | 'expense';
+  period: string;
+  budgeted: number;
+  actual: number;
+  variance: number;
+  variancePct: number | null;
+}
+
+export async function getForecastComparison(
+  forecastId: number,
+  companyId: number,
+  startPeriod?: string,
+  endPeriod?: string
+): Promise<ComparisonRow[]> {
+  const items = await db
+    .select()
+    .from(forecastItems)
+    .where(eq(forecastItems.forecastId, forecastId));
+
+  const streams = await db
+    .select()
+    .from(forecastStreams)
+    .where(eq(forecastStreams.forecastId, forecastId));
+
+  const streamMap = new Map(streams.map((s) => [s.id, s]));
+
+  let pvQuery = db
+    .select()
+    .from(forecastPeriodValues)
+    .where(eq(forecastPeriodValues.forecastId, forecastId))
+    .$dynamic();
+
+  if (startPeriod) {
+    pvQuery = pvQuery.where(
+      and(
+        eq(forecastPeriodValues.forecastId, forecastId),
+        sql`${forecastPeriodValues.period} >= ${startPeriod}`
+      )
+    );
+  }
+  if (endPeriod) {
+    pvQuery = pvQuery.where(
+      and(
+        eq(forecastPeriodValues.forecastId, forecastId),
+        sql`${forecastPeriodValues.period} <= ${endPeriod}`
+      )
+    );
+  }
+
+  const periodValues = await pvQuery;
+
+  // Gather actuals: income by categoryId+period, expenses by categoryId+period
+  const incomeActuals: Record<string, number> = {};
+  const expenseActuals: Record<string, number> = {};
+
+  // Get unique income category ids referenced by items
+  const incomeCategoryIds = [...new Set(items.filter((i) => i.incomeCategoryId).map((i) => i.incomeCategoryId!))]
+  const expenseCategoryIds = [...new Set(items.filter((i) => i.expenseCategoryId).map((i) => i.expenseCategoryId!))]
+
+  if (incomeCategoryIds.length > 0) {
+    const incomeRows = await db
+      .select({
+        categoryId: income.categoryId,
+        period: sql<string>`TO_CHAR(${income.incomeDate}, 'YYYY-MM')`,
+        total: sum(sql<number>`CAST(${income.amount} AS DECIMAL)`),
+      })
+      .from(income)
+      .where(
+        and(
+          eq(income.companyId, companyId),
+          eq(income.softDelete, false),
+          sql`${income.categoryId} = ANY(ARRAY[${sql.raw(incomeCategoryIds.join(','))}])`
+        )
+      )
+      .groupBy(income.categoryId, sql`TO_CHAR(${income.incomeDate}, 'YYYY-MM')`);
+
+    for (const row of incomeRows) {
+      const key = `${row.categoryId}__${row.period}`;
+      incomeActuals[key] = (incomeActuals[key] ?? 0) + Number(row.total ?? 0);
+    }
+  }
+
+  if (expenseCategoryIds.length > 0) {
+    const expenseRows = await db
+      .select({
+        categoryId: expenses.categoryId,
+        period: sql<string>`TO_CHAR(${expenses.expenseDate}, 'YYYY-MM')`,
+        total: sum(sql<number>`CAST(${expenses.amount} AS DECIMAL)`),
+      })
+      .from(expenses)
+      .where(
+        and(
+          eq(expenses.companyId, companyId),
+          eq(expenses.softDelete, false),
+          sql`${expenses.categoryId} = ANY(ARRAY[${sql.raw(expenseCategoryIds.join(','))}])`
+        )
+      )
+      .groupBy(expenses.categoryId, sql`TO_CHAR(${expenses.expenseDate}, 'YYYY-MM')`);
+
+    for (const row of expenseRows) {
+      const key = `${row.categoryId}__${row.period}`;
+      expenseActuals[key] = (expenseActuals[key] ?? 0) + Number(row.total ?? 0);
+    }
+  }
+
+  const itemMap = new Map(items.map((i) => [i.id, i]));
+
+  const rows: ComparisonRow[] = periodValues.map((pv) => {
+    const item = itemMap.get(pv.itemId);
+    if (!item) return null as unknown as ComparisonRow;
+
+    const stream = streamMap.get(item.streamId);
+    const streamType = (stream?.type ?? 'revenue') as 'revenue' | 'expense';
+    const budgeted = Number(pv.amount);
+
+    let actual = 0;
+    if (streamType === 'revenue' && item.incomeCategoryId) {
+      actual = incomeActuals[`${item.incomeCategoryId}__${pv.period}`] ?? 0;
+    } else if (streamType === 'expense' && item.expenseCategoryId) {
+      actual = expenseActuals[`${item.expenseCategoryId}__${pv.period}`] ?? 0;
+    }
+
+    const variance = actual - budgeted;
+    const variancePct = budgeted !== 0 ? (variance / Math.abs(budgeted)) * 100 : null;
+
+    return {
+      itemId: pv.itemId,
+      itemName: item.name,
+      streamType,
+      period: pv.period,
+      budgeted,
+      actual,
+      variance,
+      variancePct,
+    };
+  }).filter(Boolean);
+
+  return rows;
+}

--- a/src/lib/forecasts/metrics.ts
+++ b/src/lib/forecasts/metrics.ts
@@ -1,0 +1,52 @@
+import { getForecastSummary } from './summary';
+
+export interface ForecastMetrics {
+  years: number[];
+  yoyGrowthRevenue: Record<number, number | null>;
+  yoyGrowthExpenses: Record<number, number | null>;
+  yoyGrowthProfit: Record<number, number | null>;
+  profitMargin: Record<number, number>;
+  burnRate: Record<number, number>; // average monthly expenses
+  runRate: Record<number, number>;  // average monthly revenue
+}
+
+export async function getForecastMetrics(forecastId: number): Promise<ForecastMetrics> {
+  const summary = await getForecastSummary(forecastId);
+  const years = Object.keys(summary.totalRevenue).map(Number).sort();
+
+  const yoyGrowthRevenue: Record<number, number | null> = {};
+  const yoyGrowthExpenses: Record<number, number | null> = {};
+  const yoyGrowthProfit: Record<number, number | null> = {};
+  const profitMargin: Record<number, number> = {};
+  const burnRate: Record<number, number> = {};
+  const runRate: Record<number, number> = {};
+
+  for (let i = 0; i < years.length; i++) {
+    const year = years[i];
+    const prevYear = years[i - 1];
+
+    const rev = summary.totalRevenue[year] ?? 0;
+    const exp = summary.totalExpenses[year] ?? 0;
+    const profit = summary.netProfit[year] ?? 0;
+
+    profitMargin[year] = rev > 0 ? (profit / rev) * 100 : 0;
+    burnRate[year] = exp / 12;
+    runRate[year] = rev / 12;
+
+    if (prevYear !== undefined) {
+      const prevRev = summary.totalRevenue[prevYear] ?? 0;
+      const prevExp = summary.totalExpenses[prevYear] ?? 0;
+      const prevProfit = summary.netProfit[prevYear] ?? 0;
+
+      yoyGrowthRevenue[year] = prevRev !== 0 ? ((rev - prevRev) / Math.abs(prevRev)) * 100 : null;
+      yoyGrowthExpenses[year] = prevExp !== 0 ? ((exp - prevExp) / Math.abs(prevExp)) * 100 : null;
+      yoyGrowthProfit[year] = prevProfit !== 0 ? ((profit - prevProfit) / Math.abs(prevProfit)) * 100 : null;
+    } else {
+      yoyGrowthRevenue[year] = null;
+      yoyGrowthExpenses[year] = null;
+      yoyGrowthProfit[year] = null;
+    }
+  }
+
+  return { years, yoyGrowthRevenue, yoyGrowthExpenses, yoyGrowthProfit, profitMargin, burnRate, runRate };
+}

--- a/src/lib/forecasts/summary.ts
+++ b/src/lib/forecasts/summary.ts
@@ -1,0 +1,77 @@
+import { db } from '@/lib/db';
+import { forecastItems, forecastPeriodValues, forecastStreams } from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
+import { sql, sum } from 'drizzle-orm';
+
+export interface StreamSummary {
+  streamId: number;
+  streamName: string;
+  streamType: 'revenue' | 'expense';
+  years: Record<number, number>;
+}
+
+export interface ForecastSummary {
+  streams: StreamSummary[];
+  totalRevenue: Record<number, number>;
+  totalExpenses: Record<number, number>;
+  netProfit: Record<number, number>;
+}
+
+export async function getForecastSummary(forecastId: number): Promise<ForecastSummary> {
+  const streams = await db
+    .select()
+    .from(forecastStreams)
+    .where(eq(forecastStreams.forecastId, forecastId))
+    .orderBy(forecastStreams.order);
+
+  const items = await db
+    .select()
+    .from(forecastItems)
+    .where(eq(forecastItems.forecastId, forecastId));
+
+  const periodValues = await db
+    .select()
+    .from(forecastPeriodValues)
+    .where(eq(forecastPeriodValues.forecastId, forecastId));
+
+  // Build item → streamId map
+  const itemStreamMap: Record<number, number> = {};
+  for (const item of items) {
+    itemStreamMap[item.id] = item.streamId;
+  }
+
+  // Aggregate per stream per year
+  const streamYearTotals: Record<number, Record<number, number>> = {};
+  for (const pv of periodValues) {
+    const streamId = itemStreamMap[pv.itemId];
+    if (streamId === undefined) continue;
+    const year = parseInt(pv.period.substring(0, 4));
+    if (!streamYearTotals[streamId]) streamYearTotals[streamId] = {};
+    streamYearTotals[streamId][year] = (streamYearTotals[streamId][year] ?? 0) + Number(pv.amount);
+  }
+
+  const allYears = [...new Set(periodValues.map((v) => parseInt(v.period.substring(0, 4))))].sort();
+
+  const streamSummaries: StreamSummary[] = streams.map((s) => ({
+    streamId: s.id,
+    streamName: s.name,
+    streamType: s.type as 'revenue' | 'expense',
+    years: Object.fromEntries(allYears.map((y) => [y, streamYearTotals[s.id]?.[y] ?? 0])),
+  }));
+
+  const totalRevenue: Record<number, number> = {};
+  const totalExpenses: Record<number, number> = {};
+  const netProfit: Record<number, number> = {};
+
+  for (const year of allYears) {
+    totalRevenue[year] = streamSummaries
+      .filter((s) => s.streamType === 'revenue')
+      .reduce((sum, s) => sum + (s.years[year] ?? 0), 0);
+    totalExpenses[year] = streamSummaries
+      .filter((s) => s.streamType === 'expense')
+      .reduce((sum, s) => sum + (s.years[year] ?? 0), 0);
+    netProfit[year] = totalRevenue[year] - totalExpenses[year];
+  }
+
+  return { streams: streamSummaries, totalRevenue, totalExpenses, netProfit };
+}

--- a/src/lib/forecasts/tracking.ts
+++ b/src/lib/forecasts/tracking.ts
@@ -1,0 +1,52 @@
+import { getForecastComparison, ComparisonRow } from './comparison';
+
+export type TrackingStatus = 'on_track' | 'at_risk' | 'off_track';
+
+export interface TrackingRow extends ComparisonRow {
+  status: TrackingStatus;
+  ratio: number | null;
+}
+
+/**
+ * Determine on-track status for each item+period.
+ * Revenue: higher actual = good (ratio = actual/budgeted)
+ * Expense: lower actual = good (ratio = budgeted/actual — spending less is better)
+ *
+ * Thresholds (applied to ratio):
+ *   >= 0.90 → on_track
+ *   0.75–0.90 → at_risk
+ *   < 0.75 → off_track
+ */
+function computeStatus(budgeted: number, actual: number, streamType: 'revenue' | 'expense'): {
+  status: TrackingStatus;
+  ratio: number | null;
+} {
+  if (budgeted === 0) return { status: 'on_track', ratio: null };
+
+  let ratio: number;
+  if (streamType === 'revenue') {
+    ratio = actual / budgeted;
+  } else {
+    // For expenses, being under budget is good
+    ratio = budgeted / (actual === 0 ? budgeted : actual);
+  }
+
+  const status: TrackingStatus =
+    ratio >= 0.9 ? 'on_track' : ratio >= 0.75 ? 'at_risk' : 'off_track';
+
+  return { status, ratio };
+}
+
+export async function getForecastTracking(
+  forecastId: number,
+  companyId: number,
+  startPeriod?: string,
+  endPeriod?: string
+): Promise<TrackingRow[]> {
+  const comparison = await getForecastComparison(forecastId, companyId, startPeriod, endPeriod);
+
+  return comparison.map((row) => {
+    const { status, ratio } = computeStatus(row.budgeted, row.actual, row.streamType);
+    return { ...row, status, ratio };
+  });
+}

--- a/src/lib/validations/forecast.ts
+++ b/src/lib/validations/forecast.ts
@@ -1,0 +1,115 @@
+import { z } from 'zod';
+
+// ── Enums ──────────────────────────────────────────────────────────────────
+
+export const forecastStreamTypeEnum = z.enum(['revenue', 'expense']);
+export type ForecastStreamType = z.infer<typeof forecastStreamTypeEnum>;
+
+export const forecastScopeTypeEnum = z.enum(['global', 'stream', 'item']);
+export type ForecastScopeType = z.infer<typeof forecastScopeTypeEnum>;
+
+// ── Forecast ───────────────────────────────────────────────────────────────
+
+const yearMonthRegex = /^\d{4}-\d{2}$/;
+
+export const forecastSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(255),
+  description: z.string().optional().nullable(),
+  startDate: z.string().regex(yearMonthRegex, 'Start date must be YYYY-MM'),
+  endDate: z.string().regex(yearMonthRegex, 'End date must be YYYY-MM'),
+  currency: z.string().default('IDR'),
+});
+
+export type ForecastFormValues = z.infer<typeof forecastSchema>;
+
+// ── Streams ────────────────────────────────────────────────────────────────
+
+export const forecastStreamSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(255),
+  type: forecastStreamTypeEnum,
+  order: z.number().int().default(0),
+});
+
+export type ForecastStreamFormValues = z.infer<typeof forecastStreamSchema>;
+
+// ── Items ──────────────────────────────────────────────────────────────────
+
+export const forecastItemSchema = z.object({
+  streamId: z.number().int().positive(),
+  name: z.string().min(1, 'Name is required').max(255),
+  description: z.string().optional().nullable(),
+  order: z.number().int().default(0),
+  incomeCategoryId: z.number().int().positive().optional().nullable(),
+  expenseCategoryId: z.number().int().positive().optional().nullable(),
+});
+
+export type ForecastItemFormValues = z.infer<typeof forecastItemSchema>;
+
+// ── Period Values ──────────────────────────────────────────────────────────
+
+export const forecastPeriodValueSchema = z.object({
+  itemId: z.number().int().positive(),
+  period: z.string().regex(yearMonthRegex, 'Period must be YYYY-MM'),
+  amount: z.string().regex(/^\d+(\.\d{1,2})?$/, 'Amount must be a valid decimal'),
+});
+
+export type ForecastPeriodValueFormValues = z.infer<typeof forecastPeriodValueSchema>;
+
+export const forecastBulkPeriodValuesSchema = z.object({
+  values: z.array(forecastPeriodValueSchema).min(1),
+});
+
+export type ForecastBulkPeriodValues = z.infer<typeof forecastBulkPeriodValuesSchema>;
+
+// ── Variables ──────────────────────────────────────────────────────────────
+
+export const forecastVariableSchema = z.object({
+  key: z.string().min(1, 'Key is required').max(100),
+  value: z.string().regex(/^-?\d+(\.\d{1,4})?$/, 'Value must be a valid decimal'),
+  description: z.string().optional().nullable(),
+});
+
+export type ForecastVariableFormValues = z.infer<typeof forecastVariableSchema>;
+
+// ── Growth Rules ───────────────────────────────────────────────────────────
+
+export const forecastGrowthRuleSchema = z.object({
+  scopeType: forecastScopeTypeEnum,
+  scopeId: z.number().int().positive().optional().nullable(),
+  year: z.number().int().min(2000).max(2100),
+  growthRate: z.string().regex(/^-?\d+(\.\d{1,4})?$/, 'Growth rate must be a valid decimal'),
+});
+
+export type ForecastGrowthRuleFormValues = z.infer<typeof forecastGrowthRuleSchema>;
+
+// ── Seasonality Weights ────────────────────────────────────────────────────
+
+export const forecastSeasonalityWeightSchema = z.object({
+  scopeType: forecastScopeTypeEnum,
+  scopeId: z.number().int().positive().optional().nullable(),
+  month: z.number().int().min(1).max(12),
+  weight: z.string().regex(/^\d+(\.\d{1,4})?$/, 'Weight must be a valid decimal'),
+});
+
+export type ForecastSeasonalityWeightFormValues = z.infer<typeof forecastSeasonalityWeightSchema>;
+
+// ── Assumptions (combined) ─────────────────────────────────────────────────
+
+export const forecastAssumptionsSchema = z.object({
+  variables: z.array(forecastVariableSchema).optional(),
+  growthRules: z.array(forecastGrowthRuleSchema).optional(),
+  seasonalityWeights: z.array(forecastSeasonalityWeightSchema).optional(),
+});
+
+export type ForecastAssumptionsFormValues = z.infer<typeof forecastAssumptionsSchema>;
+
+// ── CSV Import ─────────────────────────────────────────────────────────────
+
+export const forecastCsvRowSchema = z.object({
+  stream: z.string().min(1),
+  item: z.string().min(1),
+  category: z.string().optional(),
+  periods: z.record(z.string().regex(yearMonthRegex), z.string()),
+});
+
+export type ForecastCsvRow = z.infer<typeof forecastCsvRowSchema>;


### PR DESCRIPTION
## Summary

This PR introduces a full **Forecasting & Budget Tracking** module to Summit Finance, giving users the ability to plan multi-year P&L forecasts, compare budgets against actuals, and track on-track/at-risk/off-track status per line item.

---

## What's Changed

### Database (7 new tables + 2 enums)

New Drizzle schema additions in `src/lib/db/schema.ts`:

| Table | Purpose |
|---|---|
| `forecasts` | Top-level forecast container (name, date range, currency) |
| `forecast_streams` | Revenue or expense groupings within a forecast |
| `forecast_items` | Individual line items, optionally linked to income/expense categories |
| `forecast_period_values` | Monthly amount per item (unique on `item_id + period`) |
| `forecast_variables` | Named constants for planning notes |
| `forecast_growth_rules` | YoY growth rates scoped to global / stream / item |
| `forecast_seasonality_weights` | Monthly distribution weights scoped to global / item |

New enums: `forecast_stream_type` (`revenue` | `expense`), `forecast_scope_type` (`global` | `stream` | `item`)

Migration: `0018_striped_machine_man.sql`

---

### API Routes (`src/app/api/forecasts/`)

| Method | Route | Description |
|---|---|---|
| GET / POST | `/api/forecasts` | List / create forecasts |
| GET / PUT / DELETE | `/api/forecasts/[id]` | Forecast detail with streams + items |
| POST / PUT / DELETE | `/api/forecasts/[id]/streams` | Manage streams |
| POST / PUT / DELETE | `/api/forecasts/[id]/items` | Manage line items + category linking |
| PUT | `/api/forecasts/[id]/revenue-periods/bulk` | Upsert monthly revenue values |
| PUT | `/api/forecasts/[id]/expense-periods/bulk` | Upsert monthly expense values |
| GET / PUT | `/api/forecasts/[id]/assumptions` | CRUD for variables, growth rules, seasonality weights |
| POST | `/api/forecasts/[id]/apply-assumptions` | Recompute period values from assumptions engine |
| GET | `/api/forecasts/[id]/summary` | Annual P&L roll-up by stream |
| GET | `/api/forecasts/[id]/metrics` | YoY growth rates, profit margin, burn/run rate |
| GET | `/api/forecasts/[id]/comparison` | Budget vs actual per item per month |
| GET | `/api/forecasts/[id]/tracking` | On-track status with variance per item |
| POST | `/api/forecasts/[id]/import` | CSV bulk import |

---

### Calculation Engine (`src/lib/forecasts/`)

- **`assumptions.ts`** — Applies YoY growth rules (global → stream → item precedence) and distributes annual totals using seasonality weights via `onConflictDoUpdate` upsert
- **`summary.ts`** — Aggregates period values into annual P&L totals per stream
- **`metrics.ts`** — Derives YoY growth %, profit margins, burn rate, run rate
- **`comparison.ts`** — Joins forecast budgets against real `income` / `expenses` records filtered by linked category ID
- **`tracking.ts`** — Computes on-track status using thresholds (≥90% = on-track, 75–90% = at-risk, <75% = off-track), with inverted logic for expense items (under-spend = good)

---

### UI Pages (`src/app/(authenticated)/forecasts/`)

| Page | Description |
|---|---|
| `/forecasts` | Card list of all forecasts with quick-action buttons |
| `/forecasts/new` | Create forecast form (name, date range, currency) |
| `/forecasts/[id]` | Spreadsheet-style editor with year tabs, inline-editable grid, stream/item sidebar |
| `/forecasts/[id]/comparison` | Budget vs actuals table with colour-coded variance columns |
| `/forecasts/[id]/tracking` | Per-month tracking dashboard with prev/next navigation and full-year bar chart |
| `/forecasts/[id]/import` | CSV file upload with preview before confirming |

### UI Components (`src/components/forecasts/`)

- **`ForecastGrid`** — Inline-editable spreadsheet grid with pending-change tracking and bulk save
- **`StreamTree`** — Collapsible sidebar tree of streams and items; click any item to assign income/expense category
- **`AssumptionsPanel`** — Dialog with tabs for growth rules (with stream/item scope picker), seasonality monthly weights, and named variables
- **`VarianceCell`** — Colour-coded variance display with on-track badge
- **`ForecastComparisonPage`** — Multi-period comparison table using `React.Fragment` keyed columns
- **`ForecastTrackingPage`** — Month navigator (prev/next + pill shortcuts), summary status cards, detail table per item, totals footer row

---

### Navigation

- Added **Forecasts** entry to the sidebar under a new **Planning** group (`TrendingUp` icon)
- Sidebar now uses prefix-match active state (`pathname.startsWith(item.href)`) so all forecast sub-pages highlight correctly

---

### Docker / CI

- Added `docker-entrypoint.sh` — waits for Postgres readiness (`pg_isready`), runs `pnpm push` to sync schema, then starts the app. Supports `SKIP_DB_SETUP=true` override
- Updated `Dockerfile` — added `postgresql-client` to runner stage, copies and uses entrypoint
- Updated `release.yml` — `latest` Docker tag now always publishes on any `v*.*.*` tag (removed `enable={{is_default_branch}}` gate)

---

### Bug Fixes

- Fixed hydration errors: `params` awaited in all dynamic route pages (Next.js 15), `<>` fragments replaced with `React.Fragment key={}` in grid and comparison tables, `<button>` nesting in `StreamTree`, missing `<tbody>` in CSV preview table
- Fixed `Header.tsx` theme toggle hydration mismatch — entire `DropdownMenu` suppressed until `mounted`, eliminating Radix ID mismatch between SSR and client
- Fixed CSV import defaulting all streams to `revenue` type — now infers `expense` from stream name via `/expense/i` regex

---

## Test Plan

- [x] Create a forecast via `/forecasts/new` → streams and items visible in editor
- [x] Import a CSV with Revenue and Expenses streams → Expenses stream type = `expense`
- [x] Edit a line item → assign income category → verify in comparison page actuals populate
- [x] Set a global growth rule → Apply Assumptions → period values for Year 2 = Year 1 × (1 + rate)
- [x] Tracking page → prev/next navigation steps through months correctly
- [ ] Push a `v*.*.*` tag → GitHub Actions builds Docker image and pushes `latest` + versioned tags to Docker Hub
- [x] Docker container on fresh DB → entrypoint runs `pnpm push`, schema created, app starts

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Forecasting System**: Added comprehensive budget forecasting with creation, editing, and management capabilities
* **Budget vs Actuals Comparison**: Added side-by-side comparison view to track budgeted amounts against actual results
* **CSV Import**: Added ability to import forecast data directly from CSV files
* **Forecast Tracking**: Added tracking dashboard with performance status indicators and period navigation
* **Assumptions Management**: Added configuration for growth rates, seasonality weights, and custom variables
* **Sidebar Navigation**: Added Forecasts section to main navigation menu

<!-- end of auto-generated comment: release notes by coderabbit.ai -->